### PR TITLE
Fix the saving behaviour of modules without state dict

### DIFF
--- a/swift/tuners/base.py
+++ b/swift/tuners/base.py
@@ -70,6 +70,8 @@ class SwiftModel(nn.Module):
         self.model = model
 
         self.extra_state_keys = extra_state_keys or []
+        self.has_additional_modules = any(
+            [c.config.has_additional_modules for c in self.adapters.values()])
 
         def forward(self, *args, **kwargs):
             return self.base_model(*args, **kwargs)
@@ -147,16 +149,20 @@ class SwiftModel(nn.Module):
         """
         state_dict = self.model.state_dict(
             destination=destination, prefix=prefix, keep_vars=keep_vars)
+        if not self.has_additional_modules:
+            return state_dict
+
         state_dicts = {}
         if kwargs.get('save_adapter', True):
             for name, output in self.adapters.items():
-                if adapter_name == name or adapter_name is None:
+                if (adapter_name == name or adapter_name is None
+                    ) and output.config.has_additional_modules:  # noqa
                     state_dicts.update(
                         output.state_dict_callback(state_dict, name))
                     modules_to_save_names = [
                         sub_name
                         for sub_name, _ in self.model.named_parameters()
-                        if 'modules_to_save' in sub_name
+                        if f'modules_to_save.{name}' in sub_name
                     ]
                     for module_name in modules_to_save_names:
                         if f'modules_to_save.{name}' in module_name:
@@ -330,11 +336,12 @@ class SwiftModel(nn.Module):
         from .mapping import SWIFT_MAPPING
 
         adatper_cls = SWIFT_MAPPING[config.swift_type][1]
-        if adatper_cls.freeze_model() and not getattr(model, 'model_freezed',
-                                                      False):
+        if adatper_cls.has_additional_modules() and not getattr(
+                model, 'model_frozen', False):
             for _, p in model.named_parameters():
                 p.requires_grad = False
-            model.model_freezed = True
+            model.model_frozen = True
+        config.has_additional_modules = adatper_cls.has_additional_modules()
         return adatper_cls.prepare_model(model, config, adapter_name)
 
     def create_or_update_model_card(self, output_dir: str):
@@ -407,10 +414,20 @@ class SwiftModel(nn.Module):
                 f'Provided path ({save_directory}) should be a directory, not a file'
             )
         os.makedirs(save_directory, exist_ok=True)
-        self.create_or_update_model_card(save_directory)
+        if not self.has_additional_modules:
+            if hasattr(self.base_model, 'save_pretrained'):
+                self.base_model.save_pretrained(
+                    save_directory, safe_serialization=safe_serialization)
+            else:
+                self._save_state_dict(self.base_model.state_dict(),
+                                      save_directory, safe_serialization)
+                self.create_or_update_model_card(save_directory)
+        else:
+            self.create_or_update_model_card(save_directory)
 
         adapter_names = adapter_name if isinstance(
             adapter_name, list) or adapter_name is None else [adapter_name]
+
         for adapter_name, output in self.adapters.items():
             if adapter_names is not None and adapter_name not in adapter_names:
                 continue
@@ -420,38 +437,44 @@ class SwiftModel(nn.Module):
                 adapter_name=adapter_name, save_extra_states=False)
             output_dir = os.path.join(save_directory, adapter_name)
             os.makedirs(output_dir, exist_ok=True)
-
-            if safe_serialization:
-                from safetensors.torch import save_file as safe_save_file
-                safe_save_file(
-                    output_state_dict,
-                    os.path.join(output_dir, SAFETENSORS_WEIGHTS_NAME),
-                    metadata={'format': 'pt'})
-            else:
-                torch.save(output_state_dict,
-                           os.path.join(output_dir, WEIGHTS_NAME))
+            if output_state_dict and output.config.has_additional_modules:
+                self._save_state_dict(output_state_dict, output_dir,
+                                      safe_serialization)
             output.config.save_pretrained(output_dir)
 
         output_state_dict = self.state_dict(
             save_extra_states=True, save_adapter=False)
         if len(output_state_dict) > 0:
-            if safe_serialization:
-                from safetensors.torch import save_file as safe_save_file
-                safe_save_file(
-                    output_state_dict,
-                    os.path.join(save_directory, SAFETENSORS_WEIGHTS_NAME),
-                    metadata={'format': 'pt'})
+            if self.has_additional_modules:
+                self._save_state_dict(output_state_dict, save_directory,
+                                      safe_serialization)
+                with open(os.path.join(save_directory, CONFIG_NAME),
+                          'w') as file:
+                    json.dump({'extra_state_keys': self.extra_state_keys},
+                              file)
             else:
-                torch.save(output_state_dict,
-                           os.path.join(save_directory, WEIGHTS_NAME))
-            with open(os.path.join(save_directory, CONFIG_NAME), 'w') as file:
-                json.dump({'extra_state_keys': self.extra_state_keys}, file)
+                logger.error(
+                    'Full parameter training, save_extra_states will be ignored'
+                )
 
         if not os.path.exists(
                 os.path.join(save_directory, 'configuration.json')):
             with open(os.path.join(save_directory, 'configuration.json'),
                       'w') as f:
                 f.write('{}')
+
+    @staticmethod
+    def _save_state_dict(output_state_dict, save_directory,
+                         safe_serialization):
+        if safe_serialization:
+            from safetensors.torch import save_file as safe_save_file
+            safe_save_file(
+                output_state_dict,
+                os.path.join(save_directory, SAFETENSORS_WEIGHTS_NAME),
+                metadata={'format': 'pt'})
+        else:
+            torch.save(output_state_dict,
+                       os.path.join(save_directory, WEIGHTS_NAME))
 
     @property
     def base_model(self):

--- a/swift/tuners/neftune.py
+++ b/swift/tuners/neftune.py
@@ -55,7 +55,7 @@ class NEFTune(SwiftAdapter):
                 sub_module.nef_activated = True
 
         def state_dict_callback(state_dict, adapter_name):
-            return {}
+            return state_dict
 
         def mark_trainable_callback(model):
             return
@@ -74,4 +74,8 @@ class NEFTune(SwiftAdapter):
 
     @staticmethod
     def freeze_model():
+        return False
+
+    @staticmethod
+    def has_additional_modules():
         return False

--- a/swift/tuners/rome/rome.py
+++ b/swift/tuners/rome/rome.py
@@ -94,7 +94,7 @@ class Rome(SwiftAdapter):
                            mark_trainable_callback)
 
     @staticmethod
-    def freeze_model():
+    def has_additional_modules():
         return False
 
 

--- a/swift/tuners/utils.py
+++ b/swift/tuners/utils.py
@@ -341,7 +341,7 @@ class SwiftAdapter:
             delattr(module, 'origin_device')
 
     @staticmethod
-    def freeze_model():
+    def has_additional_modules():
         return True
 
 

--- a/tests/tuners/test_neft.py
+++ b/tests/tuners/test_neft.py
@@ -4,9 +4,11 @@ import tempfile
 import unittest
 
 import torch
-from modelscope import AutoTokenizer, Model, Preprocessor
+from modelscope import AutoModel, AutoTokenizer, Preprocessor
+from peft.utils import WEIGHTS_NAME
+from transformers import PreTrainedModel
 
-from swift import Swift
+from swift import LoRAConfig, Swift
 from swift.tuners import NEFTuneConfig
 
 
@@ -23,18 +25,96 @@ class TestNEFT(unittest.TestCase):
         super().tearDown()
 
     def test_neft(self):
-        model = Model.from_pretrained(
-            'damo/nlp_structbert_sentence-similarity_chinese-base')
+        model = AutoModel.from_pretrained('AI-ModelScope/bert-base-uncased')
         preprocessor = Preprocessor.from_pretrained(
             'damo/nlp_structbert_sentence-similarity_chinese-base')
         inputs = preprocessor('how are you')
         config = NEFTuneConfig()
 
-        t1 = model.encoder.embeddings.word_embeddings(inputs['input_ids'])
+        t1 = model.embeddings.word_embeddings(inputs['input_ids'])
         model = Swift.prepare_model(model, config)
         model.train()
-        t2 = model.encoder.embeddings.word_embeddings(inputs['input_ids'])
+        t2 = model.embeddings.word_embeddings(inputs['input_ids'])
         model.deactivate_adapter('default')
-        t3 = model.encoder.embeddings.word_embeddings(inputs['input_ids'])
+        t3 = model.embeddings.word_embeddings(inputs['input_ids'])
         self.assertTrue(torch.allclose(t1, t3))
         self.assertFalse(torch.allclose(t1, t2))
+        model.save_pretrained(self.tmp_dir)
+        bin_file = os.path.join(self.tmp_dir, 'pytorch_model.bin')
+        self.assertTrue(os.path.isfile(bin_file))
+        model2 = AutoModel.from_pretrained(self.tmp_dir)
+
+        state_dict = model.state_dict()
+        state_dict2 = model2.state_dict()
+        self.assertTrue(len(state_dict) > 0)
+        for key in state_dict:
+            self.assertTrue(key in state_dict2)
+            self.assertTrue(
+                all(
+                    torch.isclose(state_dict[key],
+                                  state_dict2[key]).flatten().detach().cpu()))
+
+        shutil.rmtree(self.tmp_dir)
+        PreTrainedModel.origin_save_pretrained = PreTrainedModel.save_pretrained
+        delattr(PreTrainedModel, 'save_pretrained')
+        model.save_pretrained(self.tmp_dir)
+        bin_file = os.path.join(self.tmp_dir, WEIGHTS_NAME)
+        self.assertTrue(os.path.isfile(bin_file))
+        model_new = AutoModel.from_pretrained(
+            'AI-ModelScope/bert-base-uncased')
+        model_new_2 = Swift.from_pretrained(model_new, self.tmp_dir)
+
+        state_dict = model.state_dict()
+        state_dict2 = model_new_2.state_dict()
+        self.assertTrue(len(state_dict) > 0)
+        for key in state_dict:
+            self.assertTrue(key in state_dict2)
+            self.assertTrue(
+                all(
+                    torch.isclose(state_dict[key],
+                                  state_dict2[key]).flatten().detach().cpu()))
+        PreTrainedModel.save_pretrained = PreTrainedModel.origin_save_pretrained
+
+    def test_neft_lora(self):
+        model = AutoModel.from_pretrained('AI-ModelScope/bert-base-uncased')
+        preprocessor = Preprocessor.from_pretrained(
+            'damo/nlp_structbert_sentence-similarity_chinese-base')
+        inputs = preprocessor('how are you')
+        config = NEFTuneConfig()
+        config2 = LoRAConfig(target_modules=['query', 'key', 'value'])
+
+        t1 = model.embeddings.word_embeddings(inputs['input_ids'])
+        model = Swift.prepare_model(model, {'c1': config, 'c2': config2})
+        model.train()
+        t2 = model.embeddings.word_embeddings(inputs['input_ids'])
+        model.deactivate_adapter('c1')
+        t3 = model.embeddings.word_embeddings(inputs['input_ids'])
+        self.assertTrue(torch.allclose(t1, t3))
+        self.assertFalse(torch.allclose(t1, t2))
+        model.save_pretrained(self.tmp_dir)
+        bin_file = os.path.join(self.tmp_dir, 'c2', WEIGHTS_NAME)
+        self.assertTrue(os.path.isfile(bin_file))
+        bin_file = os.path.join(self.tmp_dir, 'c1', WEIGHTS_NAME)
+        self.assertTrue(not os.path.isfile(bin_file))
+        model_new = AutoModel.from_pretrained(
+            'AI-ModelScope/bert-base-uncased')
+        t1 = model_new.embeddings.word_embeddings(inputs['input_ids'])
+        model_new = Swift.from_pretrained(model_new, self.tmp_dir)
+        model_new.train()
+        t2 = model_new.embeddings.word_embeddings(inputs['input_ids'])
+        model_new.deactivate_adapter('c1')
+        t3 = model_new.embeddings.word_embeddings(inputs['input_ids'])
+        self.assertTrue(torch.allclose(t1, t3))
+        self.assertFalse(torch.allclose(t1, t2))
+
+        state_dict = model.state_dict()
+        state_dict2 = model_new.state_dict()
+        self.assertTrue(
+            len(state_dict) > 0
+            and all(['lora' in key for key in state_dict.keys()]))
+        for key in state_dict:
+            self.assertTrue(key in state_dict2)
+            self.assertTrue(
+                all(
+                    torch.isclose(state_dict[key],
+                                  state_dict2[key]).flatten().detach().cpu()))

--- a/tests/tuners/test_neft.py
+++ b/tests/tuners/test_neft.py
@@ -102,9 +102,13 @@ class TestNEFT(unittest.TestCase):
         model_new = Swift.from_pretrained(model_new, self.tmp_dir)
         model_new.train()
         t2 = model_new.embeddings.word_embeddings(inputs['input_ids'])
+        model_new.eval()
+        t4 = model_new.embeddings.word_embeddings(inputs['input_ids'])
+        model_new.train()
         model_new.deactivate_adapter('c1')
         t3 = model_new.embeddings.word_embeddings(inputs['input_ids'])
         self.assertTrue(torch.allclose(t1, t3))
+        self.assertTrue(torch.allclose(t1, t4))
         self.assertFalse(torch.allclose(t1, t2))
 
         state_dict = model.state_dict()


### PR DESCRIPTION
call save_pretrained:
1. (with lora, neftune): save adapter subfolders, neftune will save only config file
2. (no lora, only neftune): base_model.save_pretrained will be called, if no save_pretrained function, state_dict will be called and saved
