### PR TITLE
 patch _get_preprocessor

### DIFF
--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -189,10 +189,16 @@ class SmartPreprocessor:
             k: v['required']
             for k, v in self.preprocessor_mapping.items()
         }
+        best_matched_cnt, best_matched = 0, None
         for k, required_keys in required_keys_mapping.items():
-            if len(set(required_keys) - keys) == 0:
-                return self.preprocessor_mapping[k]['preprocessor']
-        raise ValueError(f"""dataset.features.keys(): {dataset.features.keys()}
+            matched = len(set(required_keys) & set(keys))
+            if matched > best_matched_cnt:
+                best_matched_cnt = matched
+                best_matched = k
+        if best_matched:
+            return self.preprocessor_mapping[best_matched]['preprocessor']
+        else:
+            raise ValueError(f"""dataset.features.keys(): {dataset.features.keys()}
 required_keys_mapping: {required_keys_mapping}""")
 
     def __call__(self, dataset: HfDataset) -> HfDataset:

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -191,7 +191,7 @@ class SmartPreprocessor:
         }
         best_matched_cnt, best_matched = 0, None
         for k, required_keys in required_keys_mapping.items():
-            matched = len(set(required_keys) & set(keys))
+            matched = len(set(required_keys) & keys)
             if matched > best_matched_cnt:
                 best_matched_cnt = matched
                 best_matched = k


### PR DESCRIPTION
感谢modelscope swift开发者提供的优秀项目！

原有方法在对 self.preprocessor_mapping 增加自定义类别时，如果新类别含有 'response', 'instruction' 则可能在执行
if len(set(required_keys) - keys) == 0  时提前返回其他内容。

修改内容：
  swift/llm/utils/preprcess.py，SmartPreprocessor -> _get_preprocessor

这里修改为最大匹配方式，如果有多个preprocessor能匹配上，则匹配最相近的。

    def _get_preprocessor(self, dataset: HfDataset) -> PreprocessFunc:
        keys = set(dataset.features.keys())
        required_keys_mapping = {
            k: v['required']
            for k, v in self.preprocessor_mapping.items()
        }
        best_matched_cnt, best_matched = 0, None
        for k, required_keys in required_keys_mapping.items():
            matched = len(set(required_keys) & keys)
            if matched > best_matched_cnt:
                best_matched_cnt = matched
                best_matched = k
        if best_matched:
            return self.preprocessor_mapping[best_matched]['preprocessor']
        else:
            raise ValueError(f"""dataset.features.keys(): {dataset.features.keys()}
