### PR TITLE
Supports to use custom datasets for models quantization

### DIFF
--- a/docs/source/LLM/LLM量化文档.md
+++ b/docs/source/LLM/LLM量化文档.md
@@ -141,10 +141,16 @@ CUDA_VISIBLE_DEVICES=0 swift infer --model_type qwen1half-7b-chat --model_id_or_
 
 **Merge-LoRA & 量化**
 ```shell
+# 使用默认数据集
 CUDA_VISIBLE_DEVICES=0 swift export \
     --ckpt_dir 'output/qwen1half-4b-chat/vx-xxx/checkpoint-xxx' \
     --merge_lora true --quant_bits 4
-
+# 使用自定义数据集
+CUDA_VISIBLE_DEVICES=0 swift export \
+    --ckpt_dir 'output/qwen1half-4b-chat/vx-xxx/checkpoint-xxx' \
+    --merge_lora true --quant_bits 4 --quant_dataset _custom_dataset \
+    --custom_train_dataset_path 'path/to/your/train/dataset' \
+    --custom_val_dataset_path 'path/to/your/val/dataset'
 ```
 
 **推理量化后模型**

--- a/docs/source/LLM/命令行参数.md
+++ b/docs/source/LLM/命令行参数.md
@@ -195,7 +195,7 @@ export参数继承了infer参数, 除此之外增加了以下参数:
 
 - `--merge_lora`: 默认为`False`. 该参数已在InferArguments中定义, 不属于新增参数. 是否将lora权重merge到基模型中, 并保存完整的权重. 权重会保存在`ckpt_dir`的同级目录中, e.g. `'/path/to/your/vx-xxx/checkpoint-xxx-merged'`目录下.
 - `--quant_bits`: awq量化的bits数. 默认为`0`, 即不进行量化. 你可以设置为`4`进行4bits量化. 权重会保存在`ckpt_dir`的同级目录中, e.g. `'/path/to/your/vx-xxx/checkpoint-xxx-int4'`目录下.
-- `--quant_dataset`: 量化数据集. 默认为`['ms-bench-mini']`, 该数据集含多语言的内容(中文为主)且质量很高, 量化中文模型具有很好的效果. 你也可以设置`--quant_dataset pileval`, 使用autoawq默认量化数据集, 该数据集的语言为英文.
+- `--quant_dataset`: 量化数据集. 默认为`['ms-bench-mini']`, 该数据集含多语言的内容(中文为主)且质量很高, 量化中文模型具有很好的效果. 你也可以设置`--quant_dataset pileval`, 使用autoawq默认量化数据集, 该数据集的语言为英文. 如果想使用自定义数据集, 可以指定`--quant_dataset _custom_dataset`, 同时指定`--custom_train_dataset_path 'path/to/your/train/dataset'`和`--custom_val_dataset_path 'path/to/your/val/dataset'`.
 - `--quant_n_samples`: awq量化参数, 默认为`1024`.
 - `--quant_seqlen`: awq量化参数, 默认为`2048`.
 - `--quant_device_map`: 默认是`'cpu'`, 你可以指定为'cuda:0', 'auto', 'cpu'等, 表示量化时模型导入的设备.

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -627,6 +627,11 @@ class ExportArguments(InferArguments):
     commit_message: str = 'update files'
 
 
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        register_custom_dataset(self)
+
+
 @dataclass
 class DPOArguments(SftArguments):
 


### PR DESCRIPTION
The previous quantization interface did not support calibration using custom datasets, so I added a feature that supports calibration using custom datasets. And I have introduced the usage method in the document.

