### PR TITLE
 [TorchAcc][Experimental] Integrate TorchAcc.

### DIFF
--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
@@ -1,0 +1,34 @@
+# Experimental environment: 4 * 8*A100
+# 80GB GPU memory
+# Note: TorchAcc is currently only available internally.
+
+export USE_TORCHACC=1
+export XLA_FLAGS='--xla_multiheap_size_constraint_per_heap=4831838208 --xla_disable_hlo_passes=all-gather-combiner,all-reduce-combiner,reduce-scatter-combiner'
+export XLA_IR_SHAPE_CACHE_SIZE=100000000
+export XLA_ALLOCATOR_FRACTION=0.97
+
+# Note: You need to set the correct MASTER_ADDR, MASTER_PORT and NODE_RANK for each node.
+
+MASTER_ADDR=127.0.0.1 \
+MASTER_PORT=12456 \
+NODE_RANK=0 \
+NNODES=4 \
+NPROC_PER_NODE=8 \
+swift sft \
+	--model_type qwen-72b-chat \
+  --model_layer_cls_name QWenBlock \
+	--dataset codefuse-python-en \
+	--sft_type full \
+  --output_dir output \
+  --num_train_epochs 1 \
+  --max_length 1024 \
+  --batch_size 1 \
+  --use_flash_attn true \
+  --gradient_accumulation_steps 1 \
+  --gradient_checkpointing no \
+  --tuner_backend 'peft' \
+  --eval_steps 2000000 \
+  --save_steps 2000000 \
+  --logging_steps 10 \
+  --preprocess_num_proc 1 \
+  --dataloader_num_workers 0

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
@@ -31,4 +31,5 @@ swift sft \
   --save_steps 2000000 \
   --logging_steps 10 \
   --preprocess_num_proc 1 \
-  --dataloader_num_workers 0
+  --dataloader_num_workers 0 \
+  --report_to 'none'

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/full_fsdp_sft.sh
@@ -15,21 +15,19 @@ NODE_RANK=0 \
 NNODES=4 \
 NPROC_PER_NODE=8 \
 swift sft \
-	--model_type qwen-72b-chat \
-  --model_layer_cls_name QWenBlock \
-	--dataset codefuse-python-en \
-	--sft_type full \
-  --output_dir output \
-  --num_train_epochs 1 \
-  --max_length 1024 \
-  --batch_size 1 \
-  --use_flash_attn true \
-  --gradient_accumulation_steps 1 \
-  --gradient_checkpointing no \
-  --tuner_backend 'peft' \
-  --eval_steps 2000000 \
-  --save_steps 2000000 \
-  --logging_steps 10 \
-  --preprocess_num_proc 1 \
-  --dataloader_num_workers 0 \
-  --report_to 'none'
+    --model_type qwen-72b-chat \
+    --model_layer_cls_name QWenBlock \
+    --dataset codefuse-python-en \
+    --sft_type full \
+    --output_dir output \
+    --num_train_epochs 1 \
+    --max_length 1024 \
+    --batch_size 1 \
+    --use_flash_attn true \
+    --gradient_accumulation_steps 1 \
+    --gradient_checkpointing no \
+    --tuner_backend 'peft' \
+    --eval_steps 200 \
+    --save_steps 200 \
+    --logging_steps 100 \
+    --report_to 'none'

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
@@ -1,14 +1,15 @@
-# Experimental environment: 2 * A800
+# Experimental environment: 4 * A800
 # 80GB GPU memory
 # Note: TorchAcc is currently only available internally.
 
 export USE_TORCHACC=1
 export XLA_FLAGS='--xla_multiheap_size_constraint_per_heap=4831838208 --xla_disable_hlo_passes=all-gather-combiner,all-reduce-combiner,reduce-scatter-combiner'
 export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.97
+export XLA_ALLOCATOR_FRACTION=0.95
+export XLA_EXPERIMENTAL=nonzero:masked_select
 
-NPROC_PER_NODE=2 \
-CUDA_VISIBLE_DEVICES=0,1 \
+NPROC_PER_NODE=4 \
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
 swift sft \
 	--model_type qwen-72b-chat \
   --model_layer_cls_name QWenBlock \
@@ -17,7 +18,7 @@ swift sft \
   --output_dir output \
   --num_train_epochs 1 \
   --max_length 1024 \
-  --batch_size 1 \
+  --batch_size 6 \
   --use_flash_attn true \
   --gradient_accumulation_steps 1 \
   --gradient_checkpointing no \

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
@@ -1,0 +1,29 @@
+# Experimental environment: 2 * A800
+# 80GB GPU memory
+# Note: TorchAcc is currently only available internally.
+
+export USE_TORCHACC=1
+export XLA_FLAGS='--xla_multiheap_size_constraint_per_heap=4831838208 --xla_disable_hlo_passes=all-gather-combiner,all-reduce-combiner,reduce-scatter-combiner'
+export XLA_IR_SHAPE_CACHE_SIZE=100000000
+export XLA_ALLOCATOR_FRACTION=0.97
+
+NPROC_PER_NODE=2 \
+CUDA_VISIBLE_DEVICES=0,1 \
+swift sft \
+	--model_type qwen-72b-chat \
+  --model_layer_cls_name QWenBlock \
+	--dataset codefuse-python-en \
+	--sft_type lora \
+  --output_dir output \
+  --num_train_epochs 1 \
+  --max_length 1024 \
+  --batch_size 1 \
+  --use_flash_attn true \
+  --gradient_accumulation_steps 1 \
+  --gradient_checkpointing no \
+  --tuner_backend 'peft' \
+  --eval_steps 2000000 \
+  --save_steps 2000000 \
+  --logging_steps 10 \
+  --preprocess_num_proc 1 \
+  --dataloader_num_workers 0

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
@@ -27,4 +27,5 @@ swift sft \
   --save_steps 2000000 \
   --logging_steps 100 \
   --preprocess_num_proc 1 \
-  --dataloader_num_workers 0
+  --dataloader_num_workers 0 \
+  --report_to 'none' \

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
@@ -3,7 +3,7 @@
 # Note: TorchAcc is currently only available internally.
 
 export USE_TORCHACC=1
-export XLA_FLAGS='--xla_multiheap_size_constraint_per_heap=4831838208 --xla_disable_hlo_passes=all-gather-combiner,all-reduce-combiner,reduce-scatter-combiner'
+export XLA_FLAGS='--xla_gpu_force_compilation_parallelism=32 --xla_multiheap_size_constraint_per_heap=4831838208 --xla_disable_hlo_passes=all-gather-combiner,all-reduce-combiner,reduce-scatter-combiner,gpu-convert-async-collectives-to-sync,rematerialization'
 export XLA_IR_SHAPE_CACHE_SIZE=100000000
 export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
@@ -15,9 +15,9 @@ swift sft \
   --model_layer_cls_name QWenBlock \
 	--dataset codefuse-python-en \
 	--sft_type lora \
-  --output_dir output \
+  --output_dir output_qwen_72b \
   --num_train_epochs 1 \
-  --max_length 1024 \
+  --max_length 2048 \
   --batch_size 6 \
   --use_flash_attn true \
   --gradient_accumulation_steps 1 \
@@ -25,6 +25,6 @@ swift sft \
   --tuner_backend 'peft' \
   --eval_steps 2000000 \
   --save_steps 2000000 \
-  --logging_steps 10 \
+  --logging_steps 100 \
   --preprocess_num_proc 1 \
   --dataloader_num_workers 0

--- a/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh
@@ -11,21 +11,19 @@ export XLA_EXPERIMENTAL=nonzero:masked_select
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \
 swift sft \
-	--model_type qwen-72b-chat \
-  --model_layer_cls_name QWenBlock \
-	--dataset codefuse-python-en \
-	--sft_type lora \
-  --output_dir output_qwen_72b \
-  --num_train_epochs 1 \
-  --max_length 2048 \
-  --batch_size 6 \
-  --use_flash_attn true \
-  --gradient_accumulation_steps 1 \
-  --gradient_checkpointing no \
-  --tuner_backend 'peft' \
-  --eval_steps 2000000 \
-  --save_steps 2000000 \
-  --logging_steps 100 \
-  --preprocess_num_proc 1 \
-  --dataloader_num_workers 0 \
-  --report_to 'none' \
+    --model_type qwen-72b-chat \
+    --model_layer_cls_name QWenBlock \
+    --dataset codefuse-python-en \
+    --sft_type lora \
+    --output_dir output_qwen_72b \
+    --num_train_epochs 1 \
+    --max_length 2048 \
+    --batch_size 6 \
+    --use_flash_attn true \
+    --gradient_accumulation_steps 1 \
+    --gradient_checkpointing no \
+    --tuner_backend 'peft' \
+    --eval_steps 200 \
+    --save_steps 200 \
+    --logging_steps 100 \
+    --report_to 'none' \

--- a/swift/llm/accelerator.py
+++ b/swift/llm/accelerator.py
@@ -1,0 +1,33 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+
+
+def ta_accelerate(model,
+                  fsdp_num,
+                  layer_cls_name,
+                  bf16=True,
+                  fp16=False,
+                  gradient_checkpointing=True,
+                  fsdp_flatten_parameters=False):
+    """ accelerate LLM training using TorchAcc(only available internally).
+    """
+    import torchacc as ta
+    assert layer_cls_name is not None
+
+    def get_ta_config():
+        config = ta.Config()
+        config.compute.fp16 = fp16
+        config.compute.bf16 = bf16
+
+        config.memory.gc = gradient_checkpointing
+        if config.memory.gc:
+            config.memory.gc_cls = {layer_cls_name}
+
+        config.dist.fsdp.size = fsdp_num
+        config.dist.fsdp.wrap_layer_cls = {layer_cls_name}
+        config.dist.fsdp.flatten_parameters = fsdp_flatten_parameters
+
+        return config
+
+    ta_config = get_ta_config()
+    model = ta.accelerate(model, ta_config)
+    return model

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -11,7 +11,7 @@ from transformers import IntervalStrategy
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import is_torch_npu_available
 
-from swift.trainers import Seq2SeqTrainer, Seq2SeqTrainingArguments
+from swift.trainers import Seq2SeqTrainer
 from swift.trainers.utils import can_return_loss, find_labels
 from swift.utils import (check_json_format, compute_acc_metrics,
                          compute_nlg_metrics, get_dist_setting, get_logger,

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -207,9 +207,10 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
     bucket_sizes = get_bucket_sizes(
         args.max_length) if use_torchacc() else None
     padding_to = args.max_length if args.sft_type == 'longlora' else None
-    data_collator = partial(template.data_collator,
-                            padding_to=padding_to,
-                            bucket_sizes=bucket_sizes)
+    data_collator = partial(
+        template.data_collator,
+        padding_to=padding_to,
+        bucket_sizes=bucket_sizes)
 
     trian_batch_size = args.batch_size
     eval_batch_size = args.eval_batch_size

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -22,10 +22,9 @@ from .accelerator import ta_accelerate
 from .tuner import prepare_model
 from .utils import (TEMPLATE_MAPPING, LazyLLMDataset, SftArguments, Template,
                     add_self_cognition_dataset, dataset_map, get_bucket_sizes,
-                    get_dataset,
-                    get_model_tokenizer, get_template, get_time_info,
-                    print_example, set_generation_config, sort_by_max_length,
-                    stat_dataset)
+                    get_dataset, get_model_tokenizer, get_template,
+                    get_time_info, print_example, set_generation_config,
+                    sort_by_max_length, stat_dataset)
 from .utils.argument import handle_dataset_mixture
 
 logger = get_logger()
@@ -216,6 +215,7 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
     data_collator = partial(template.data_collator,
                             padding_to=padding_to,
                             bucket_sizes=bucket_sizes)
+
     trian_batch_size = args.batch_size
     eval_batch_size = args.eval_batch_size
     if use_torchacc():
@@ -223,7 +223,7 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         eval_batch_size *= world_size
     training_args.per_device_train_batch_size = trian_batch_size
     training_args.per_device_eval_batch_size = eval_batch_size
-    training_args.group_by_length=use_torchacc()
+    training_args.group_by_length = use_torchacc()
 
     # Trainer
     logger.info(f'training_args: {training_args}')
@@ -276,7 +276,7 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         f'best_model_checkpoint: {trainer.state.best_model_checkpoint}')
     train_time = get_time_info(trainer.state.log_history, len(train_dataset))
     # Visualization
-    if is_master():
+    if is_master() and not use_torchacc():
         images_dir = os.path.join(args.output_dir, 'images')
         logger.info(f'images_dir: {images_dir}')
         plot_images(images_dir, args.logging_dir, ['train/loss'], 0.9)

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -11,6 +11,7 @@ from transformers import IntervalStrategy
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import is_torch_npu_available
 
+from swift.torchacc_utils import get_bucket_sizes
 from swift.trainers import Seq2SeqTrainer
 from swift.trainers.utils import can_return_loss, find_labels
 from swift.utils import (check_json_format, compute_acc_metrics,
@@ -21,10 +22,10 @@ from swift.utils import (check_json_format, compute_acc_metrics,
 from .accelerator import ta_accelerate
 from .tuner import prepare_model
 from .utils import (TEMPLATE_MAPPING, LazyLLMDataset, SftArguments, Template,
-                    add_self_cognition_dataset, dataset_map, get_bucket_sizes,
-                    get_dataset, get_model_tokenizer, get_template,
-                    get_time_info, print_example, set_generation_config,
-                    sort_by_max_length, stat_dataset)
+                    add_self_cognition_dataset, dataset_map, get_dataset,
+                    get_model_tokenizer, get_template, get_time_info,
+                    print_example, set_generation_config, sort_by_max_length,
+                    stat_dataset)
 from .utils.argument import handle_dataset_mixture
 
 logger = get_logger()
@@ -66,7 +67,6 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
             args.load_in_4bit,
             bnb_4bit_compute_dtype=args.bnb_4bit_compute_dtype,
             bnb_4bit_quant_type=args.bnb_4bit_quant_type,
-            bnb_4bit_quant_storage=args.bnb_4bit_quant_storage,
             bnb_4bit_use_double_quant=args.bnb_4bit_use_double_quant)
         logger.info(f'quantization_config: {quantization_config.__dict__}')
         model_kwargs['quantization_config'] = quantization_config
@@ -293,7 +293,8 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
 
 def get_sft_main(args, llm):
     if use_torchacc():
-        logger.warning('TorchAcc is currently only available internally.')
+        logger.warning('TorchAcc is currently only available internally '
+                       'within Alibaba Cloud.')
         import torchacc as ta
         # This patch should be called before `llm_sft`.
         ta.accelerate_hf_trainer()

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -290,6 +290,7 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         'dataset_info': dataset_info,
     }
 
+
 def get_sft_main(args, llm):
     if use_torchacc():
         logger.warning('TorchAcc is currently only available internally.')
@@ -297,5 +298,6 @@ def get_sft_main(args, llm):
         # This patch should be called before `llm_sft`.
         ta.accelerate_hf_trainer()
     return get_main(args, llm)
+
 
 sft_main = get_sft_main(SftArguments, llm_sft)

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -31,7 +31,6 @@ logger = get_logger()
 
 
 def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
-
     logger.info(f'args: {args}')
     training_args = args.training_args
     if is_torch_npu_available():
@@ -60,10 +59,6 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
             model_kwargs['device_map'] = {'': local_rank}
         elif not use_torchacc():
             model_kwargs['device_map'] = 'auto'
-    if use_torchacc():
-        logger.warning('TorchAcc is currently only available internally.')
-        import torchacc as ta
-        ta.accelerate_hf_trainer()
 
     if args.load_in_8bit or args.load_in_4bit:
         quantization_config = BitsAndBytesConfig(
@@ -295,5 +290,12 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         'dataset_info': dataset_info,
     }
 
+def get_sft_main(args, llm):
+    if use_torchacc():
+        logger.warning('TorchAcc is currently only available internally.')
+        import torchacc as ta
+        # This patch should be called before `llm_sft`.
+        ta.accelerate_hf_trainer()
+    return get_main(args, llm)
 
-sft_main = get_main(SftArguments, llm_sft)
+sft_main = get_sft_main(SftArguments, llm_sft)

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -11,7 +11,6 @@ from transformers import IntervalStrategy
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import is_torch_npu_available
 
-from swift.torchacc_utils import get_bucket_sizes
 from swift.trainers import Seq2SeqTrainer
 from swift.trainers.utils import can_return_loss, find_labels
 from swift.utils import (check_json_format, compute_acc_metrics,
@@ -204,13 +203,8 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         if val_dataset is not None:
             val_dataset = LazyLLMDataset(val_dataset, template)
 
-    bucket_sizes = get_bucket_sizes(
-        args.max_length) if use_torchacc() else None
     padding_to = args.max_length if args.sft_type == 'longlora' else None
-    data_collator = partial(
-        template.data_collator,
-        padding_to=padding_to,
-        bucket_sizes=bucket_sizes)
+    data_collator = partial(template.data_collator, padding_to=padding_to)
 
     trian_batch_size = args.batch_size
     eval_batch_size = args.eval_batch_size

--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -216,6 +216,15 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
     data_collator = partial(template.data_collator,
                             padding_to=padding_to,
                             bucket_sizes=bucket_sizes)
+    trian_batch_size = args.batch_size
+    eval_batch_size = args.eval_batch_size
+    if use_torchacc():
+        trian_batch_size *= world_size
+        eval_batch_size *= world_size
+    training_args.per_device_train_batch_size = trian_batch_size
+    training_args.per_device_eval_batch_size = eval_batch_size
+    training_args.group_by_length=use_torchacc()
+
     # Trainer
     logger.info(f'training_args: {training_args}')
 

--- a/swift/llm/tuner.py
+++ b/swift/llm/tuner.py
@@ -1,4 +1,5 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+import os
 import types
 
 import torch
@@ -6,13 +7,14 @@ import transformers
 from packaging import version
 
 from swift.trainers import TrainerCallback
+from swift.trainers.utils import consolidate_checkpoint
 from swift.tuners import (AdaLoraConfig, IA3Config, LongLoRAConfig,
                           LongLoRAModelType, LoraConfig, LoRAConfig,
                           NEFTuneConfig, Swift)
 from swift.tuners.llamapro import LLaMAProConfig
 from swift.tuners.module_mapping import MODEL_KEYS_MAPPING
 from swift.utils import (activate_model_parameters, freeze_model_parameters,
-                         get_logger)
+                         get_logger, use_torchacc)
 from .utils import (SftArguments, find_all_linears, find_embedding, find_ln,
                     is_adapter)
 
@@ -149,6 +151,9 @@ def prepare_model(model, args: SftArguments):
                 model = Swift.prepare_model(model, llamapro_config)
                 logger.info(f'llamapro_config: {llamapro_config}')
         else:
+            if use_torchacc():
+                consolidate_checkpoint(args.resume_from_checkpoint,
+                                       'adapter_model')
             model = Swift.from_pretrained(
                 model, args.resume_from_checkpoint, is_trainable=True)
         # fix bug: Attempting to unscale FP16 gradients.
@@ -168,6 +173,14 @@ def prepare_model(model, args: SftArguments):
         if len(args.additional_trainable_parameters) > 0:
             activate_model_parameters(model,
                                       args.additional_trainable_parameters)
+        if use_torchacc() and args.resume_from_checkpoint is not None:
+            consolidate_checkpoint(args.resume_from_checkpoint, 'model')
+            weights_file = os.path.join(args.resume_from_checkpoint,
+                                        'model.bin')
+            state_dict = torch.load(weights_file, map_location='cpu')
+            model.load_state_dict(state_dict, False)
+            # release memory
+            del state_dict
     else:
         raise ValueError(f'args.sft_type: {args.sft_type}')
 

--- a/swift/llm/tuner.py
+++ b/swift/llm/tuner.py
@@ -6,8 +6,8 @@ import torch
 import transformers
 from packaging import version
 
+from swift.torchacc_utils import consolidate_checkpoint
 from swift.trainers import TrainerCallback
-from swift.trainers.utils import consolidate_checkpoint
 from swift.tuners import (AdaLoraConfig, IA3Config, LongLoRAConfig,
                           LongLoRAModelType, LoraConfig, LoRAConfig,
                           NEFTuneConfig, Swift)

--- a/swift/llm/utils/__init__.py
+++ b/swift/llm/utils/__init__.py
@@ -27,8 +27,8 @@ from .protocol import (ChatCompletionRequest, ChatCompletionResponseChoice,
                        CompletionStreamResponse, DeltaMessage, Model,
                        ModelList, UsageInfo, XRequestConfig, random_uuid)
 from .template import (DEFAULT_SYSTEM, TEMPLATE_MAPPING, History, Prompt,
-                       StopWords, Template, TemplateType, get_bucket_sizes,
-                       get_template, register_template)
+                       StopWords, Template, TemplateType, get_template,
+                       register_template)
 from .utils import (LazyLLMDataset, LLMDataset, dataset_map, download_dataset,
                     find_all_linears, find_embedding, find_ln,
                     get_max_model_len, get_time_info, history_to_messages,

--- a/swift/llm/utils/__init__.py
+++ b/swift/llm/utils/__init__.py
@@ -27,8 +27,8 @@ from .protocol import (ChatCompletionRequest, ChatCompletionResponseChoice,
                        CompletionStreamResponse, DeltaMessage, Model,
                        ModelList, UsageInfo, XRequestConfig, random_uuid)
 from .template import (DEFAULT_SYSTEM, TEMPLATE_MAPPING, History, Prompt,
-                       StopWords, Template, TemplateType, get_template,
-                       register_template)
+                       StopWords, Template, TemplateType, get_bucket_sizes,
+                       get_template, register_template)
 from .utils import (LazyLLMDataset, LLMDataset, dataset_map, download_dataset,
                     find_all_linears, find_embedding, find_ln,
                     get_max_model_len, get_time_info, history_to_messages,

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -49,6 +49,12 @@ class SftArguments:
         metadata={'help': f'model_type choices: {list(MODEL_MAPPING.keys())}'})
     model_id_or_path: Optional[str] = None
     model_revision: Optional[str] = None
+    model_layer_cls_name: Optional[str] = field(
+        default=None,
+        metadata={
+            'help':
+            "Decoder Class name of model, e.g. 'QWenBlock' for QWen, 'LlamaDecoderLayer' for LLama"
+        })
 
     sft_type: Literal['lora', 'full', 'longlora', 'qalora', 'adalora', 'ia3',
                       'llamapro'] = 'lora'

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -26,7 +26,7 @@ from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from transformers.utils.versions import require_version
 
 from swift import get_logger
-from swift.utils import is_dist, is_local_master
+from swift.utils import is_dist, is_local_master, use_torchacc
 from .template import TemplateType
 from .utils import get_max_model_len
 
@@ -2952,7 +2952,7 @@ def get_model_tokenizer(
     get_function = model_info['get_function']
     if model_kwargs is None:
         model_kwargs = {}
-    if 'device_map' not in model_kwargs:
+    if 'device_map' not in model_kwargs and not use_torchacc():
         model_kwargs['device_map'] = 'auto'
 
     if model_info.get('torch_dtype') is not None:

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -463,6 +463,9 @@ class Template:
                                   tokenizer.pad_token_id)
                 attention_mask = F.pad(attention_mask, (0, padding_length),
                                        'constant', 0)
+                if loss_scale:
+                    loss_scale = F.pad(loss_scale, (0, padding_length),
+                                       'constant', 0.)
                 labels = F.pad(labels, (0, padding_length), 'constant', -100)
 
             # manully split the batch to different DP rank.
@@ -473,6 +476,8 @@ class Template:
                 input_ids = input_ids[start:end, :]
                 attention_mask = attention_mask[start:end, :]
                 labels = labels[start:end, :]
+                if loss_scale:
+                    loss_scale = loss_scale[start:end, :]
 
         res = {
             'input_ids': input_ids,

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -436,8 +436,7 @@ class Template:
             rank, _, world_size, _ = get_dist_setting()
             input_ids, attention_mask, labels, loss_scale = pad_and_split_batch(
                 res['input_ids'], res['attention_mask'], res['labels'],
-                loss_scale, padding_to, bucket_sizes, self.tokenizer, rank,
-                world_size)
+                loss_scale, bucket_sizes, self.tokenizer, rank, world_size)
             res['input_ids'] = input_ids
             res['attention_mask'] = attention_mask
             res['labels'] = labels

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import requests
+import sys
 import torch
 import torch.nn.functional as F
 from torch import Tensor
@@ -11,6 +12,7 @@ from torch.nn.utils.rnn import pad_sequence
 from transformers import PreTrainedTokenizerBase, StoppingCriteria
 
 from swift.llm.agent.utils import calculate_loss_scale
+from swift.utils import use_torchacc
 
 DEFAULT_SYSTEM = 'You are a helpful assistant.'
 History = List[Union[Tuple[str, str], List[str]]]
@@ -119,6 +121,26 @@ def _replace_system(prefix: Prompt) -> Prompt:
             p = p.replace('{{SYSTEM}}', '')
         res.append(p)
     return res
+
+
+def get_bucket_sizes(max_length: int) -> List[int]:
+    return [max_length // 4 * (i + 1) for i in range(4)]
+
+
+def _get_bucket(bucket_sizes, data_length):
+    """Select the one from bucket_sizes that is closest in distance to
+    data_length. This is required for TorchAcc.
+    """
+    cloest_length = sys.maxsize
+    for b in bucket_sizes:
+        if b == data_length or ((b < cloest_length) and (b > data_length)):
+            cloest_length = b
+
+    if cloest_length == sys.maxsize:
+        bucket_sizes.append(data_length)
+        cloest_length = data_length
+
+    return cloest_length
 
 
 class Template:
@@ -388,12 +410,14 @@ class Template:
 
     def data_collator(self,
                       batch: List[Dict[str, Any]],
-                      padding_to: Optional[int] = None) -> Dict[str, Any]:
+                      padding_to: Optional[int] = None,
+                      bucket_sizes: Optional[List[int]] = None) -> Dict[str, Any]:
         """
         Args:
             batch(`List[Dict[str, Any]]`): The input data in batch
             padding_to(`int`, optional): Whether padding the batch to a fixed length, if none, the batch
                 will be padded to the `longest`
+            bucket_sizes(`List[int]`, optional): Bucket sizes of sequence for TorchAcc.
         """
         tokenizer = self.tokenizer
         assert tokenizer.pad_token_id is not None
@@ -428,6 +452,17 @@ class Template:
             loss_scale = pad_sequence(
                 loss_scale, batch_first=True, padding_value=0.)
         labels = pad_sequence(labels, batch_first=True, padding_value=-100)
+
+
+        if padding_to is None and use_torchacc():
+            longest_len = input_ids.shape[-1]
+            bucket_data_length = _get_bucket(bucket_sizes, longest_len)
+            padding_length = bucket_data_length - input_ids.shape[1]
+            input_ids = F.pad(input_ids, (0, padding_length), 'constant',
+                              tokenizer.pad_token_id)
+            attention_mask = F.pad(attention_mask, (0, padding_length), 'constant',
+                                  0)
+            labels = F.pad(labels, (0, padding_length), 'constant', -100)
 
         res = {
             'input_ids': input_ids,

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -462,7 +462,7 @@ class Template:
                 input_ids = F.pad(input_ids, (0, padding_length), 'constant',
                                   tokenizer.pad_token_id)
                 attention_mask = F.pad(attention_mask, (0, padding_length),
-                                      'constant', 0)
+                                       'constant', 0)
                 labels = F.pad(labels, (0, padding_length), 'constant', -100)
 
             # manully split the batch to different DP rank.

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -1,10 +1,10 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+import sys
 from copy import deepcopy
 from io import BytesIO
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import requests
-import sys
 import torch
 import torch.nn.functional as F
 from torch import Tensor
@@ -460,8 +460,8 @@ class Template:
             padding_length = bucket_data_length - input_ids.shape[1]
             input_ids = F.pad(input_ids, (0, padding_length), 'constant',
                               tokenizer.pad_token_id)
-            attention_mask = F.pad(attention_mask, (0, padding_length), 'constant',
-                                  0)
+            attention_mask = F.pad(attention_mask, (0, padding_length),
+                                   'constant', 0)
             labels = F.pad(labels, (0, padding_length), 'constant', -100)
 
         res = {

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -431,20 +431,18 @@ class Template:
         if loss_scale:
             loss_scale = pad_sequence(
                 loss_scale, batch_first=True, padding_value=0.)
-        labels = pad_sequence(labels, batch_first=True, padding_value=-100)
 
         if use_torchacc():
             rank, _, world_size, _ = get_dist_setting()
             input_ids, attention_mask, labels, loss_scale = pad_and_split_batch(
-                input_ids, attention_mask, labels, loss_scale, padding_to,
-                bucket_sizes, tokenizer, rank, world_size)
+                res['input_ids'], res['attention_mask'], res['labels'],
+                loss_scale, padding_to, bucket_sizes, self.tokenizer, rank,
+                world_size)
+            res['input_ids'] = input_ids
+            res['attention_mask'] = attention_mask
+            res['labels'] = labels
 
-        res = {
-            'input_ids': input_ids,
-            'attention_mask': attention_mask,
-            'labels': labels,
-        }
-        if loss_scale is not None:
+        if loss_scale:
             res['loss_scale'] = loss_scale
         return res
 

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -388,17 +388,14 @@ class Template:
         assert len(old_tokenizer_kwargs) == 0
         return curr_tokenizer_kwargs
 
-    def data_collator(
-            self,
-            batch: List[Dict[str, Any]],
-            padding_to: Optional[int] = None,
-            bucket_sizes: Optional[List[int]] = None) -> Dict[str, Any]:
+    def data_collator(self,
+                      batch: List[Dict[str, Any]],
+                      padding_to: Optional[int] = None) -> Dict[str, Any]:
         """
         Args:
             batch(`List[Dict[str, Any]]`): The input data in batch
             padding_to(`int`, optional): Whether padding the batch to a fixed length, if none, the batch
                 will be padded to the `longest`
-            bucket_sizes(`List[int]`, optional): Bucket sizes of sequence for TorchAcc.
         """
         tokenizer = self.tokenizer
         assert tokenizer.pad_token_id is not None
@@ -438,7 +435,7 @@ class Template:
             rank, _, world_size, _ = get_dist_setting()
             input_ids, attention_mask, labels, loss_scale = pad_and_split_batch(
                 padding_to, input_ids, attention_mask, labels, loss_scale,
-                bucket_sizes, self.tokenizer, rank, world_size)
+                self.max_length, self.tokenizer, rank, world_size)
 
         res = {
             'input_ids': input_ids,

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -299,7 +299,6 @@ def stat_dataset(llm_dataset: Dataset) -> str:
     logger.info(f'Dataset Token Length: {stat_str}')
     return stat_str
 
-
 def safe_tokenizer_decode(tokenizer: PreTrainedTokenizerBase,
                           input_ids: List[int], **tokenizer_kwargs) -> str:
     if len(input_ids) == 0:

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -5,6 +5,7 @@ import importlib.util
 import logging
 import os
 import shutil
+import sys
 from copy import deepcopy
 from functools import partial, wraps
 from queue import Empty, Queue
@@ -41,6 +42,7 @@ from swift.hub import ModelScopeConfig
 from swift.tuners.module_mapping import MODEL_KEYS_MAPPING
 from swift.utils import (get_dist_setting, get_logger, is_ddp_plus_mp, is_dist,
                          is_local_master, is_master, stat_array, upper_bound)
+                         use_torchacc)
 from .template import History, StopWords, StopWordsCriteria, Template
 
 logger = get_logger()
@@ -321,7 +323,6 @@ def safe_tokenizer_decode(tokenizer: PreTrainedTokenizerBase,
     else:
         result_str += tokenizer.decode(input_ids[e:], **tokenizer_kwargs)
     return result_str
-
 
 def print_example(example: Dict[str, Any],
                   tokenizer: PreTrainedTokenizerBase,
@@ -868,6 +869,8 @@ if is_ddp_plus_mp():
         _old_ddp_init(self, model, *args, **kwargs))
     transformers.modeling_utils.get_balanced_memory = lambda *args, **kwargs: None
     transformers.modeling_utils.infer_auto_device_map = _infer_auto_device_map_patch
+
+if is_ddp_plus_mp() or use_torchacc():
     _old_accelerator_init = trainer.Accelerator.__init__
     trainer.Accelerator.__init__ = (
         lambda self, device_placement=False, *args, **kwargs:

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -41,7 +41,7 @@ from transformers.generation.streamers import BaseStreamer
 from swift.hub import ModelScopeConfig
 from swift.tuners.module_mapping import MODEL_KEYS_MAPPING
 from swift.utils import (get_dist_setting, get_logger, is_ddp_plus_mp, is_dist,
-                         is_local_master, is_master, stat_array, upper_bound)
+                         is_local_master, is_master, stat_array, upper_bound,
                          use_torchacc)
 from .template import History, StopWords, StopWordsCriteria, Template
 
@@ -299,6 +299,7 @@ def stat_dataset(llm_dataset: Dataset) -> str:
     logger.info(f'Dataset Token Length: {stat_str}')
     return stat_str
 
+
 def safe_tokenizer_decode(tokenizer: PreTrainedTokenizerBase,
                           input_ids: List[int], **tokenizer_kwargs) -> str:
     if len(input_ids) == 0:
@@ -322,6 +323,7 @@ def safe_tokenizer_decode(tokenizer: PreTrainedTokenizerBase,
     else:
         result_str += tokenizer.decode(input_ids[e:], **tokenizer_kwargs)
     return result_str
+
 
 def print_example(example: Dict[str, Any],
                   tokenizer: PreTrainedTokenizerBase,

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -39,9 +39,10 @@ def _get_closet_bucket(bucket_sizes, data_length):
 
 
 def pad_and_split_batch(padding_to, input_ids, attention_mask, labels,
-                        loss_scale, bucket_sizes, tokenizer, rank, world_size):
+                        loss_scale, max_length, tokenizer, rank, world_size):
     if padding_to is None:
         longest_len = input_ids.shape[-1]
+        bucket_sizes = get_bucket_sizes(max_length)
         bucket_data_length = _get_closet_bucket(bucket_sizes, longest_len)
         padding_length = bucket_data_length - input_ids.shape[1]
         input_ids = F.pad(input_ids, (0, padding_length), 'constant',

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
 import os
 import sys
 from collections import OrderedDict
@@ -38,18 +39,16 @@ def _get_closet_bucket(bucket_sizes, data_length):
 
 
 def pad_and_split_batch(input_ids, attention_mask, labels, loss_scale,
-                        padding_to, bucket_sizes, tokenizer, rank, world_size):
-    if padding_to is None:
-        longest_len = input_ids.shape[-1]
-        bucket_data_length = _get_closet_bucket(bucket_sizes, longest_len)
-        padding_length = bucket_data_length - input_ids.shape[1]
-        input_ids = F.pad(input_ids, (0, padding_length), 'constant',
-                          tokenizer.pad_token_id)
-        attention_mask = F.pad(attention_mask, (0, padding_length), 'constant',
-                               0)
-        if loss_scale:
-            loss_scale = F.pad(loss_scale, (0, padding_length), 'constant', 0.)
-        labels = F.pad(labels, (0, padding_length), 'constant', -100)
+                        bucket_sizes, tokenizer, rank, world_size):
+    longest_len = input_ids.shape[-1]
+    bucket_data_length = _get_closet_bucket(bucket_sizes, longest_len)
+    padding_length = bucket_data_length - input_ids.shape[1]
+    input_ids = F.pad(input_ids, (0, padding_length), 'constant',
+                      tokenizer.pad_token_id)
+    attention_mask = F.pad(attention_mask, (0, padding_length), 'constant', 0)
+    if loss_scale:
+        loss_scale = F.pad(loss_scale, (0, padding_length), 'constant', 0.)
+    labels = F.pad(labels, (0, padding_length), 'constant', -100)
 
     # manully split the batch to different DP rank.
     batch_size = input_ids.shape[0] // world_size

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -1,0 +1,285 @@
+import os
+import sys
+from collections import OrderedDict
+from typing import List
+
+import safetensors
+import torch
+import torch.nn.functional as F
+from peft import PeftModel
+from torch.utils.data import DataLoader
+from transformers import PreTrainedModel, trainer
+from transformers.modeling_utils import unwrap_model
+
+from swift.utils import get_logger
+
+logger = get_logger()
+
+
+# DataLoader
+def get_bucket_sizes(max_length: int) -> List[int]:
+    return [max_length // 4 * (i + 1) for i in range(4)]
+
+
+def _get_closet_bucket(bucket_sizes, data_length):
+    """Select the one from bucket_sizes that is closest in distance to
+    data_length. This is required for TorchAcc.
+    """
+    cloest_length = sys.maxsize
+    for b in bucket_sizes:
+        if b == data_length or ((b < cloest_length) and (b > data_length)):
+            cloest_length = b
+
+    if cloest_length == sys.maxsize:
+        bucket_sizes.append(data_length)
+        cloest_length = data_length
+
+    return cloest_length
+
+
+def pad_and_split_batch(input_ids, attention_mask, labels, loss_scale,
+                        padding_to, bucket_sizes, tokenizer, rank, world_size):
+    if padding_to is None:
+        longest_len = input_ids.shape[-1]
+        bucket_data_length = _get_closet_bucket(bucket_sizes, longest_len)
+        padding_length = bucket_data_length - input_ids.shape[1]
+        input_ids = F.pad(input_ids, (0, padding_length), 'constant',
+                          tokenizer.pad_token_id)
+        attention_mask = F.pad(attention_mask, (0, padding_length), 'constant',
+                               0)
+        if loss_scale:
+            loss_scale = F.pad(loss_scale, (0, padding_length), 'constant', 0.)
+        labels = F.pad(labels, (0, padding_length), 'constant', -100)
+
+    # manully split the batch to different DP rank.
+    batch_size = input_ids.shape[0] // world_size
+    if batch_size > 0:
+        start = rank * batch_size
+        end = (rank + 1) * batch_size
+        input_ids = input_ids[start:end, :]
+        attention_mask = attention_mask[start:end, :]
+        labels = labels[start:end, :]
+        if loss_scale:
+            loss_scale = loss_scale[start:end, :]
+    return input_ids, attention_mask, labels, loss_scale
+
+
+def ta_train_dataloader(train_dataset, data_collator, sampler, args,
+                        batch_size):
+    # patch skip_first_batches for customized dataloader.
+    def acc_skip_first_batches(dataloader, num_batches=0):
+        from accelerate.data_loader import SkipBatchSampler
+        batch_sampler = SkipBatchSampler(
+            dataloader._loader.batch_sampler, skip_batches=num_batches)
+        dataset = dataloader.dataset
+        dataloader_params = {
+            'collate_fn': data_collator,
+            'num_workers': args.dataloader_num_workers,
+            'pin_memory': args.dataloader_pin_memory,
+            'persistent_workers': args.dataloader_persistent_workers,
+        }
+
+        if not isinstance(train_dataset, torch.utils.data.IterableDataset):
+            dataloader_params['batch_sampler'] = batch_sampler
+            dataloader_params['worker_init_fn'] = trainer.seed_worker
+
+        return ta.AsyncLoader(
+            DataLoader(dataset, **dataloader_params), args.device)
+
+    trainer.skip_first_batches = acc_skip_first_batches
+
+    # dataloader for TorchAcc.
+    import torchacc as ta
+
+    dataloader_params = {
+        'batch_size': batch_size,
+        'collate_fn': data_collator,
+        'num_workers': args.dataloader_num_workers,
+        'pin_memory': args.dataloader_pin_memory,
+        'persistent_workers': args.dataloader_persistent_workers,
+    }
+
+    if not isinstance(train_dataset, torch.utils.data.IterableDataset):
+        dataloader_params['sampler'] = sampler
+        dataloader_params['drop_last'] = args.dataloader_drop_last
+        dataloader_params['worker_init_fn'] = trainer.seed_worker
+
+    return ta.AsyncLoader(
+        DataLoader(train_dataset, **dataloader_params), args.device)
+
+
+def ta_eval_dataloader(eval_dataset, data_collator, sampler, args):
+    import torchacc as ta
+
+    dataloader_params = {
+        'batch_size': args.eval_batch_size,
+        'collate_fn': data_collator,
+        'num_workers': args.dataloader_num_workers,
+        'pin_memory': args.dataloader_pin_memory,
+        'persistent_workers': args.dataloader_persistent_workers,
+    }
+
+    if not isinstance(eval_dataset, torch.utils.data.IterableDataset):
+        dataloader_params['sampler'] = sampler
+        dataloader_params['drop_last'] = args.dataloader_drop_last
+
+    return ta.AsyncLoader(
+        DataLoader(eval_dataset, **dataloader_params), args.device)
+
+
+def ta_test_dataloader(test_dataset, data_collator, sampler, args):
+    import torchacc as ta
+
+    dataloader_params = {
+        'batch_size': args.eval_batch_size,
+        'collate_fn': data_collator,
+        'num_workers': args.dataloader_num_workers,
+        'pin_memory': args.dataloader_pin_memory,
+        'persistent_workers': args.dataloader_persistent_workers,
+    }
+
+    if not isinstance(test_dataset, torch.utils.data.IterableDataset):
+        dataloader_params['sampler'] = sampler
+        dataloader_params['drop_last'] = args.dataloader_drop_last
+
+    # We use the same batch_size as for eval.
+    return ta.AsyncLoader(
+        DataLoader(test_dataset, **dataloader_params), args.device)
+
+
+# Save/load checkpoint
+def consolidate_checkpoint(resume_from_checkpoint, model_name='adapter_model'):
+    """ Consolidate the sharded TorchAcc checkpoints into a single model checkpoint.
+    """
+    import torch_xla.core.xla_model as xm
+    from torch_xla.distributed.fsdp import consolidate_sharded_state_dicts
+
+    if model_name not in ('adapter_model', 'model'):
+        logger.error('Only support PeftModel and PreTrainedModel.')
+        return
+
+    model_dir = os.path.join(resume_from_checkpoint, '0')
+    is_pretrained_model = False
+    if os.path.exists(os.path.join(model_dir, f'{model_name}.safetensors')):
+        use_safetensors = True
+    elif os.path.exists(os.path.join(model_dir, f'{model_name}.bin')):
+        use_safetensors = False
+    elif os.path.exists(os.path.join(model_dir, 'pytorch_model.bin')):
+        # PreTrainedModel use 'pytorch_model.bin' and 'model.safetensors'
+        use_safetensors = False
+        is_pretrained_model = True
+    else:
+        logger.error('Cannot find checkpoint.')
+
+    state_dict_list = []
+    if xm.is_master_ordinal(local=False) and use_safetensors:
+        from safetensors.torch import load_file, save_file
+        for rank in range(xm.xrt_world_size()):
+            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
+            filename = os.path.join(shard_dir, f'{model_name}.safetensors')
+            state_dict = load_file(filename, device='cpu')
+            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
+                                     for k, v in state_dict.items())
+            state_dict_list.append(state_dict)
+        shard_metadata = torch.load(
+            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
+    elif xm.is_master_ordinal(local=False):
+        for rank in range(xm.xrt_world_size()):
+            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
+            if not is_pretrained_model:
+                filename = os.path.join(shard_dir, f'{model_name}.bin')
+            else:
+                filename = os.path.join(shard_dir, 'pytorch_model.bin')
+            state_dict = torch.load(filename, map_location='cpu')
+            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
+                                     for k, v in state_dict.items())
+            state_dict_list.append(state_dict)
+        shard_metadata = torch.load(
+            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
+
+    if xm.is_master_ordinal(local=False):
+        full_state_dict = consolidate_sharded_state_dicts(
+            state_dict_list, shard_metadata)
+        # peft will prepend "default." prefix automatically, so we remove the
+        # "default." prefix to prevent the duplication of the prefix.
+        full_state_dict = OrderedDict(
+            (k.replace('default.', ''), v) for k, v in full_state_dict.items())
+        torch.save(full_state_dict,
+                   os.path.join(resume_from_checkpoint, f'{model_name}.bin'))
+        if model_name == 'adapter_model':
+            config_path = os.path.join(resume_from_checkpoint,
+                                       'adapter_config.json')
+            old_config_path = os.path.join(model_dir, 'adapter_config.json')
+            os.system(f'cp {old_config_path} {config_path}')
+    xm.rendezvous('ckpt_consolidation')
+
+
+def ta_save_optimizer_and_scheduler(optimizer, lr_scheduler, output_dir):
+    import torch_xla.core.xla_model as xm
+    xm.rendezvous('saving_optimizer_states')
+    torch.save(optimizer.state_dict(),
+               os.path.join(output_dir, f'optimizer_{xm.get_ordinal()}.pt'))
+    torch.save(lr_scheduler.state_dict(),
+               os.path.join(output_dir, f'scheduler_{xm.get_ordinal()}.pt'))
+
+
+def ta_load_optimizer_and_scheduler(optimizer, lr_scheduler, checkpoint,
+                                    device):
+    import torch_xla.core.xla_model as xm
+    optimizer_state = torch.load(
+        os.path.join(checkpoint, f'optimizer_{xm.get_ordinal()}.pt'),
+        map_location='cpu')
+    lr_scheduler_state = torch.load(
+        os.path.join(checkpoint, f'scheduler_{xm.get_ordinal()}.pt'),
+        map_location='cpu')
+    xm.send_cpu_data_to_device(optimizer_state, device)
+    xm.send_cpu_data_to_device(lr_scheduler_state, device)
+
+    optimizer.load_state_dict(optimizer_state)
+    lr_scheduler.load_state_dict(lr_scheduler_state)
+    return optimizer, lr_scheduler
+
+
+def save_ta_checkpoint(self_model, tokenizer, args, output_dir):
+    import torch_xla.core.xla_model as xm
+
+    if xm.is_master_ordinal(local=False):
+        os.makedirs(output_dir, exist_ok=True)
+        torch.save(args, os.path.join(output_dir, 'training_args.bin'))
+
+    model = self_model._get_underlay_model().module.module
+
+    supported_classes = (PreTrainedModel, PeftModel)
+    save_safetensors = args.save_safetensors
+    # Save a trained model and configuration using `save_pretrained()`.
+    # They can then be reloaded using `from_pretrained()`
+    xm.rendezvous('saving_checkpoint')
+    out_dir = os.path.join(output_dir, f'{xm.get_ordinal()}')
+    if not isinstance(model, supported_classes):
+        state_dict = model.state_dict()
+        _unwrap_model = unwrap_model(model)
+        if isinstance(_unwrap_model, supported_classes):
+            _unwrap_model.save_pretrained(
+                out_dir, safe_serialization=save_safetensors)
+        else:
+            logger.info(
+                'Trainer.model is not a `PreTrainedModel`, only saving its state dict.'
+            )
+            if save_safetensors:
+                safetensors.torch.save_file(
+                    state_dict, os.path.join(out_dir, 'model.safetensors'))
+            else:
+                torch.save(state_dict,
+                           os.path.join(out_dir, 'pytorch_model.bin'))
+    else:
+        model.save_pretrained(out_dir, safe_serialization=save_safetensors)
+    # save shard_metadata for consolidation.
+    shard_meta = self_model._get_underlay_model().get_shard_metadata()
+    xm.save(shard_meta, os.path.join(out_dir, 'shard_meta.pth'))
+    xm.rendezvous('saving_checkpoint_done')
+
+    if tokenizer is not None and args.should_save:
+        tokenizer.save_pretrained(
+            output_dir,
+            is_main_process=xm.is_master_ordinal(local=False),
+            save_function=xm.save)

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -10,7 +10,7 @@ from transformers.training_args_seq2seq import \
     Seq2SeqTrainingArguments as HfSeq2SeqTrainingArguments
 from transformers.utils import is_accelerate_available
 
-from swift.utils import is_dist
+from swift.utils import is_dist, use_torchacc
 
 
 @dataclass
@@ -52,4 +52,7 @@ class TrainingArguments(SwiftArgumentsMixin, HfTrainingArguments):
 @dataclass
 class Seq2SeqTrainingArguments(SwiftArgumentsMixin,
                                HfSeq2SeqTrainingArguments):
-    pass
+
+    @property
+    def place_model_on_device(self):
+        return False if use_torchacc() else super().place_model_on_device

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -16,10 +16,8 @@ import transformers
 from datasets import Dataset as HfDataset
 from packaging import version
 from peft import PeftModel
-from torch import nn
 from torch.nn import Module
-from transformers import (PreTrainedModel, PreTrainedTokenizerBase,
-                          is_bitsandbytes_available)
+from transformers import PreTrainedModel, PreTrainedTokenizerBase
 from transformers.data.data_collator import DataCollator
 from transformers.modeling_utils import unwrap_model
 from transformers.trainer import ADAPTER_CONFIG_NAME  # noqa
@@ -34,6 +32,9 @@ from transformers.training_args import TrainingArguments
 
 from swift.hub import Repository
 from swift.hub.check_model import check_local_model_is_latest
+from swift.torchacc_utils import (save_ta_checkpoint,
+                                  ta_load_optimizer_and_scheduler,
+                                  ta_save_optimizer_and_scheduler)
 from swift.tuners import SwiftModel
 from swift.utils import (check_json_format, create_ms_repo, get_logger,
                          use_torchacc)
@@ -364,14 +365,8 @@ class SwiftMixin:
         if not use_torchacc():
             return super()._save_optimizer_and_scheduler(output_dir)
 
-        import torch_xla.core.xla_model as xm
-        xm.rendezvous('saving_optimizer_states')
-        torch.save(
-            self.optimizer.state_dict(),
-            os.path.join(output_dir, f'optimizer_{xm.get_ordinal()}.pt'))
-        torch.save(
-            self.lr_scheduler.state_dict(),
-            os.path.join(output_dir, f'scheduler_{xm.get_ordinal()}.pt'))
+        ta_save_optimizer_and_scheduler(self.optimizer, self.lr_scheduler,
+                                        output_dir)
 
     def _load_optimizer_and_scheduler(self, checkpoint):
         if not use_torchacc():
@@ -379,67 +374,17 @@ class SwiftMixin:
 
         if checkpoint is None or self.args.save_only_model:
             return
-        import torch_xla.core.xla_model as xm
-        optimizer_state = torch.load(
-            os.path.join(checkpoint, f'optimizer_{xm.get_ordinal()}.pt'),
-            map_location='cpu')
-        lr_scheduler_state = torch.load(
-            os.path.join(checkpoint, f'scheduler_{xm.get_ordinal()}.pt'),
-            map_location='cpu')
-        xm.send_cpu_data_to_device(optimizer_state, self.args.device)
-        xm.send_cpu_data_to_device(lr_scheduler_state, self.args.device)
 
-        self.optimizer.load_state_dict(optimizer_state)
-        self.lr_scheduler.load_state_dict(lr_scheduler_state)
+        self.optimizer, self.lr_scheduler = ta_load_optimizer_and_scheduler(
+            self.optimizer, self.lr_scheduler, checkpoint, self.args.device)
 
     def _save_tpu(self, output_dir: Optional[str] = None):
         if not use_torchacc():
             return super()._save_tpu(output_dir)
 
-        import torch_xla.core.xla_model as xm
-
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         logger.info(f'Saving model checkpoint to {output_dir}')
-
-        if xm.is_master_ordinal(local=False):
-            os.makedirs(output_dir, exist_ok=True)
-            torch.save(self.args, os.path.join(output_dir,
-                                               'training_args.bin'))
-        model = self.model._get_underlay_model().module.module
-        supported_classes = (PreTrainedModel, PeftModel)
-        save_safetensors = self.args.save_safetensors
-        # Save a trained model and configuration using `save_pretrained()`.
-        # They can then be reloaded using `from_pretrained()`
-        xm.rendezvous('saving_checkpoint')
-        out_dir = os.path.join(output_dir, f'{xm.get_ordinal()}')
-        if not isinstance(model, supported_classes):
-            state_dict = model.state_dict()
-            _unwrap_model = unwrap_model(model)
-            if isinstance(_unwrap_model, supported_classes):
-                _unwrap_model.save_pretrained(
-                    out_dir, safe_serialization=save_safetensors)
-            else:
-                logger.info(
-                    'Trainer.model is not a `PreTrainedModel`, only saving its state dict.'
-                )
-                if save_safetensors:
-                    safetensors.torch.save_file(
-                        state_dict, os.path.join(out_dir, 'model.safetensors'))
-                else:
-                    torch.save(state_dict,
-                               os.path.join(out_dir, 'pytorch_model.bin'))
-        else:
-            model.save_pretrained(out_dir, safe_serialization=save_safetensors)
-        # save shard_metadata for consolidation.
-        shard_meta = self.model._get_underlay_model().get_shard_metadata()
-        xm.save(shard_meta, os.path.join(out_dir, 'shard_meta.pth'))
-        xm.rendezvous('saving_checkpoint_done')
-
-        if self.tokenizer is not None and self.args.should_save:
-            self.tokenizer.save_pretrained(
-                output_dir,
-                is_main_process=xm.is_master_ordinal(local=False),
-                save_function=xm.save)
+        save_ta_checkpoint(self.model, self.tokenizer, self.args, output_dir)
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         """Compatible with swift and peft"""

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -7,6 +7,7 @@ import torch
 from peft import PeftModel
 from torch import Tensor, nn
 from torch.nn import CrossEntropyLoss
+from torch.utils.data import DataLoader
 from transformers import Seq2SeqTrainer as HfSeq2SeqTrainer
 from transformers import Trainer as HfTrainer
 from transformers import trainer
@@ -15,7 +16,7 @@ from transformers.models.auto.modeling_auto import \
     MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 from transformers.utils import is_peft_available
 
-from swift.utils import lower_bound, use_torchacc
+from swift.utils import use_torchacc
 from .callback import (DefaultFlowCallbackNew, PrinterCallbackNew,
                        ProgressCallbackNew)
 from .mixin import PushToMsHubMixin, SwiftMixin
@@ -254,16 +255,127 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
                                                     m]).to(torch.int64).item())
             acc = torch.tensor(acc_list, device=preds.device).float().mean()
         else:
-            if not use_torchacc():
-                acc = (preds[masks] == labels[masks]).float().mean()
-            else:
-                acc = (preds == labels).float().mean()
+            acc = (torch.masked_select(preds, masks) == torch.masked_select(
+                labels, masks)).float().mean()
         if model.training and acc is not None:
             if 'acc' not in self._custom_metrics:
                 self._custom_metrics['acc'] = self._acc
             self._custom_metrics['acc'] = self._custom_metrics[
                 'acc'] + acc / self.args.gradient_accumulation_steps
         return (loss, outputs) if return_outputs else loss
+
+    def get_train_dataloader(self):
+        if not use_torchacc():
+            return super().get_train_dataloader()
+        else:
+            import torchacc as ta
+            if trainer.is_datasets_available():
+                import datasets
+
+            if self.train_dataset is None:
+                raise ValueError('Trainer: training requires a train_dataset.')
+
+            train_dataset = self.train_dataset
+            data_collator = self.data_collator
+
+            if trainer.is_datasets_available() and isinstance(
+                    train_dataset, datasets.Dataset):
+                train_dataset = self._remove_unused_columns(
+                    train_dataset, description='training')
+            else:
+                data_collator = self._get_collator_with_removed_columns(
+                    data_collator, description='training')
+            dataloader_params = {
+                'batch_size': self._train_batch_size,
+                'collate_fn': data_collator,
+                'num_workers': self.args.dataloader_num_workers,
+                'pin_memory': self.args.dataloader_pin_memory,
+                'persistent_workers': self.args.dataloader_persistent_workers,
+            }
+
+            if not isinstance(train_dataset, torch.utils.data.IterableDataset):
+                dataloader_params['sampler'] = self._get_train_sampler()
+                dataloader_params['drop_last'] = self.args.dataloader_drop_last
+                dataloader_params['worker_init_fn'] = trainer.seed_worker
+
+            return ta.AsyncLoader(
+                DataLoader(train_dataset, **dataloader_params),
+                self.args.device)
+
+    def get_eval_dataloader(self, eval_dataset):
+        if not use_torchacc():
+            return super().get_eval_dataloader(eval_dataset)
+        else:
+            import torchacc as ta
+            if trainer.is_datasets_available():
+                import datasets
+
+            if eval_dataset is None and self.eval_dataset is None:
+                raise ValueError(
+                    'Trainer: evaluation requires an eval_dataset.')
+            eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
+            data_collator = self.data_collator
+
+            if trainer.is_datasets_available() and isinstance(
+                    eval_dataset, datasets.Dataset):
+                eval_dataset = self._remove_unused_columns(
+                    eval_dataset, description='evaluation')
+            else:
+                data_collator = self._get_collator_with_removed_columns(
+                    data_collator, description='evaluation')
+
+            dataloader_params = {
+                'batch_size': self.args.eval_batch_size,
+                'collate_fn': data_collator,
+                'num_workers': self.args.dataloader_num_workers,
+                'pin_memory': self.args.dataloader_pin_memory,
+                'persistent_workers': self.args.dataloader_persistent_workers,
+            }
+
+            if not isinstance(eval_dataset, torch.utils.data.IterableDataset):
+                dataloader_params['sampler'] = self._get_eval_sampler(
+                    eval_dataset)
+                dataloader_params['drop_last'] = self.args.dataloader_drop_last
+
+            return ta.AsyncLoader(
+                DataLoader(eval_dataset, **dataloader_params),
+                self.args.device)
+
+    def get_test_dataloader(self, test_dataset):
+        if not use_torchacc():
+            return super().get_test_dataloader(test_dataset)
+        else:
+            import torchacc as ta
+            if trainer.is_datasets_available():
+                import datasets
+
+            data_collator = self.data_collator
+
+            if trainer.is_datasets_available() and isinstance(
+                    test_dataset, datasets.Dataset):
+                test_dataset = self._remove_unused_columns(
+                    test_dataset, description='test')
+            else:
+                data_collator = self._get_collator_with_removed_columns(
+                    data_collator, description='test')
+
+            dataloader_params = {
+                'batch_size': self.args.eval_batch_size,
+                'collate_fn': data_collator,
+                'num_workers': self.args.dataloader_num_workers,
+                'pin_memory': self.args.dataloader_pin_memory,
+                'persistent_workers': self.args.dataloader_persistent_workers,
+            }
+
+            if not isinstance(test_dataset, torch.utils.data.IterableDataset):
+                dataloader_params['sampler'] = self._get_eval_sampler(
+                    test_dataset)
+                dataloader_params['drop_last'] = self.args.dataloader_drop_last
+
+            # We use the same batch_size as for eval.
+            return ta.AsyncLoader(
+                DataLoader(test_dataset, **dataloader_params),
+                self.args.device)
 
 
 # monkey patching

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -268,6 +268,31 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
         if not use_torchacc():
             return super().get_train_dataloader()
         else:
+            # patch skip_first_batches for customized dataloader.
+            def acc_skip_first_batches(dataloader, num_batches=0):
+                from accelerate.data_loader import SkipBatchSampler
+                batch_sampler = SkipBatchSampler(
+                    dataloader._loader.batch_sampler, skip_batches=num_batches)
+                dataset = dataloader.dataset
+                dataloader_params = {
+                    'collate_fn': data_collator,
+                    'num_workers': self.args.dataloader_num_workers,
+                    'pin_memory': self.args.dataloader_pin_memory,
+                    'persistent_workers':
+                    self.args.dataloader_persistent_workers,
+                }
+
+                if not isinstance(train_dataset,
+                                  torch.utils.data.IterableDataset):
+                    dataloader_params['batch_sampler'] = batch_sampler
+                    dataloader_params['worker_init_fn'] = trainer.seed_worker
+
+                return ta.AsyncLoader(
+                    DataLoader(dataset, **dataloader_params), self.args.device)
+
+            trainer.skip_first_batches = acc_skip_first_batches
+
+            # dataloader for TorchAcc.
             import torchacc as ta
             if trainer.is_datasets_available():
                 import datasets

--- a/swift/trainers/utils.py
+++ b/swift/trainers/utils.py
@@ -2,20 +2,27 @@
 # Part of the implementation is borrowed from huggingface/transformers.
 
 import inspect
+import os
+from collections import OrderedDict
 from types import FunctionType, MethodType
 from typing import List, Union
 
+import torch
 from torch.nn import Module
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import (EvaluationStrategy, FSDPOption,
                                         HPSearchBackend, HubStrategy,
                                         IntervalStrategy, SchedulerType)
 
+from swift.utils import get_logger
+
 try:
     # https://github.com/huggingface/transformers/pull/25702
     from transformers.trainer_utils import ShardedDDPOption
 except ImportError:
     ShardedDDPOption = None
+
+logger = get_logger()
 
 
 def can_return_loss(model: Module) -> bool:
@@ -55,3 +62,69 @@ def is_instance_of_ms_model(model: Module) -> bool:
         if cls_name == 'Model' and cls_module.startswith('modelscope'):
             return True
     return False
+
+
+def consolidate_checkpoint(resume_from_checkpoint, model_name='adapter_model'):
+    """ Consolidate the sharded TorchAcc checkpoints into a single model checkpoint.
+    """
+    import torch_xla.core.xla_model as xm
+    from torch_xla.distributed.fsdp import consolidate_sharded_state_dicts
+
+    if model_name not in ('adapter_model', 'model'):
+        logger.error('Only support PeftModel and PreTrainedModel.')
+        return
+
+    model_dir = os.path.join(resume_from_checkpoint, '0')
+    is_pretrained_model = False
+    if os.path.exists(os.path.join(model_dir, f'{model_name}.safetensors')):
+        use_safetensors = True
+    elif os.path.exists(os.path.join(model_dir, f'{model_name}.bin')):
+        use_safetensors = False
+    elif os.path.exists(os.path.join(model_dir, 'pytorch_model.bin')):
+        # PreTrainedModel use 'pytorch_model.bin' and 'model.safetensors'
+        use_safetensors = False
+        is_pretrained_model = True
+    else:
+        logger.error('Cannot find checkpoint.')
+
+    state_dict_list = []
+    if xm.is_master_ordinal(local=False) and use_safetensors:
+        from safetensors.torch import load_file, save_file
+        for rank in range(xm.xrt_world_size()):
+            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
+            filename = os.path.join(shard_dir, f'{model_name}.safetensors')
+            state_dict = load_file(filename, device='cpu')
+            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
+                                     for k, v in state_dict.items())
+            state_dict_list.append(state_dict)
+        shard_metadata = torch.load(
+            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
+    elif xm.is_master_ordinal(local=False):
+        for rank in range(xm.xrt_world_size()):
+            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
+            if not is_pretrained_model:
+                filename = os.path.join(shard_dir, f'{model_name}.bin')
+            else:
+                filename = os.path.join(shard_dir, 'pytorch_model.bin')
+            state_dict = torch.load(filename, map_location='cpu')
+            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
+                                     for k, v in state_dict.items())
+            state_dict_list.append(state_dict)
+        shard_metadata = torch.load(
+            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
+
+    if xm.is_master_ordinal(local=False):
+        full_state_dict = consolidate_sharded_state_dicts(
+            state_dict_list, shard_metadata)
+        # peft will prepend "default." prefix automatically, so we remove the
+        # "default." prefix to prevent the duplication of the prefix.
+        full_state_dict = OrderedDict(
+            (k.replace('default.', ''), v) for k, v in full_state_dict.items())
+        torch.save(full_state_dict,
+                   os.path.join(resume_from_checkpoint, f'{model_name}.bin'))
+        if model_name == 'adapter_model':
+            config_path = os.path.join(resume_from_checkpoint,
+                                       'adapter_config.json')
+            old_config_path = os.path.join(model_dir, 'adapter_config.json')
+            os.system(f'cp {old_config_path} {config_path}')
+    xm.rendezvous('ckpt_consolidation')

--- a/swift/trainers/utils.py
+++ b/swift/trainers/utils.py
@@ -2,12 +2,9 @@
 # Part of the implementation is borrowed from huggingface/transformers.
 
 import inspect
-import os
-from collections import OrderedDict
 from types import FunctionType, MethodType
 from typing import List, Union
 
-import torch
 from torch.nn import Module
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import (EvaluationStrategy, FSDPOption,
@@ -62,69 +59,3 @@ def is_instance_of_ms_model(model: Module) -> bool:
         if cls_name == 'Model' and cls_module.startswith('modelscope'):
             return True
     return False
-
-
-def consolidate_checkpoint(resume_from_checkpoint, model_name='adapter_model'):
-    """ Consolidate the sharded TorchAcc checkpoints into a single model checkpoint.
-    """
-    import torch_xla.core.xla_model as xm
-    from torch_xla.distributed.fsdp import consolidate_sharded_state_dicts
-
-    if model_name not in ('adapter_model', 'model'):
-        logger.error('Only support PeftModel and PreTrainedModel.')
-        return
-
-    model_dir = os.path.join(resume_from_checkpoint, '0')
-    is_pretrained_model = False
-    if os.path.exists(os.path.join(model_dir, f'{model_name}.safetensors')):
-        use_safetensors = True
-    elif os.path.exists(os.path.join(model_dir, f'{model_name}.bin')):
-        use_safetensors = False
-    elif os.path.exists(os.path.join(model_dir, 'pytorch_model.bin')):
-        # PreTrainedModel use 'pytorch_model.bin' and 'model.safetensors'
-        use_safetensors = False
-        is_pretrained_model = True
-    else:
-        logger.error('Cannot find checkpoint.')
-
-    state_dict_list = []
-    if xm.is_master_ordinal(local=False) and use_safetensors:
-        from safetensors.torch import load_file, save_file
-        for rank in range(xm.xrt_world_size()):
-            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
-            filename = os.path.join(shard_dir, f'{model_name}.safetensors')
-            state_dict = load_file(filename, device='cpu')
-            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
-                                     for k, v in state_dict.items())
-            state_dict_list.append(state_dict)
-        shard_metadata = torch.load(
-            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
-    elif xm.is_master_ordinal(local=False):
-        for rank in range(xm.xrt_world_size()):
-            shard_dir = os.path.join(resume_from_checkpoint, f'{rank}')
-            if not is_pretrained_model:
-                filename = os.path.join(shard_dir, f'{model_name}.bin')
-            else:
-                filename = os.path.join(shard_dir, 'pytorch_model.bin')
-            state_dict = torch.load(filename, map_location='cpu')
-            state_dict = OrderedDict(('_fsdp_wrapped_module.' + k, v)
-                                     for k, v in state_dict.items())
-            state_dict_list.append(state_dict)
-        shard_metadata = torch.load(
-            os.path.join(model_dir, 'shard_meta.pth'), map_location='cpu')
-
-    if xm.is_master_ordinal(local=False):
-        full_state_dict = consolidate_sharded_state_dicts(
-            state_dict_list, shard_metadata)
-        # peft will prepend "default." prefix automatically, so we remove the
-        # "default." prefix to prevent the duplication of the prefix.
-        full_state_dict = OrderedDict(
-            (k.replace('default.', ''), v) for k, v in full_state_dict.items())
-        torch.save(full_state_dict,
-                   os.path.join(resume_from_checkpoint, f'{model_name}.bin'))
-        if model_name == 'adapter_model':
-            config_path = os.path.join(resume_from_checkpoint,
-                                       'adapter_config.json')
-            old_config_path = os.path.join(model_dir, 'adapter_config.json')
-            os.system(f'cp {old_config_path} {config_path}')
-    xm.rendezvous('ckpt_consolidation')

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -18,4 +18,3 @@ from .utils import (add_version_to_work_dir, check_json_format,
                     get_pai_tensorboard_dir, is_pai_training_job, lower_bound,
                     parse_args, read_multi_line, seed_everything,
                     subprocess_run, test_time, upper_bound)
-

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -13,8 +13,9 @@ from .torch_utils import (activate_model_parameters, broadcast_string,
                           freeze_model_parameters, get_dist_setting,
                           get_model_info, is_ddp_plus_mp, is_dist,
                           is_local_master, is_master, is_mp, is_on_same_device,
-                          show_layers, time_synchronize)
+                          show_layers, time_synchronize, use_torchacc)
 from .utils import (add_version_to_work_dir, check_json_format,
                     get_pai_tensorboard_dir, is_pai_training_job, lower_bound,
                     parse_args, read_multi_line, seed_everything,
                     subprocess_run, test_time, upper_bound)
+

--- a/swift/utils/torch_utils.py
+++ b/swift/utils/torch_utils.py
@@ -74,13 +74,21 @@ def is_local_master():
     return local_rank in {-1, 0}
 
 
+def use_torchacc() -> bool:
+    return os.getenv('USE_TORCHACC', '0') == '1'
+
+
 def is_dist():
     """Determine if the training is distributed"""
+    if use_torchacc():
+        return False
     rank, local_rank, _, _ = get_dist_setting()
     return rank >= 0 and local_rank >= 0
 
 
 def is_mp() -> bool:
+    if use_torchacc():
+        return False
     n_gpu = torch.cuda.device_count()
     local_world_size = get_dist_setting()[3]
     assert n_gpu % local_world_size == 0


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Model or Dataset Support

# PR information
TorchAcc is a framework developed by Alibaba PAI to accelerate PyTorch model training, providing computational acceleration based on compilation optimization and distributed strategies such as FSDP and TP+SP. This PR uses TorchAcc to accelerate the training of Swift SFT LoRA and Full scenarios and provides examples of qwen-72b-chat. Users can enable TorchAcc acceleration by setting `export USE_TORCHACC=1`. Currently, this feature is still in the experimental stage and only available internally.


## Experiment results
Test with 4*80G A100 on qwen-72b-chat lora with script: 
```sh examples/pytorch/llm/scripts/qwen_72b_chat/torchacc/lora_fsdp_sft.sh```

{"eval_loss": 0.35520425, "eval_acc": 0.87996558, "eval_runtime": 753.7452, "eval_samples_per_second": 0.362, "eval_steps_per_second": 0.004, "epoch": 1.0, "global_step": 1123}
{"train_runtime": 13049.8116, "train_samples_per_second": 2.065, "train_steps_per_second": 0.086, "total_flos": 0.0, "train_loss": 0.36302515, "epoch": 1.0, "global_step": 1123}
