### PR TITLE
fix multimodal model image_mode = 'CMYK' (fix issue#677)

### DIFF
--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -580,7 +580,7 @@ def _read_from_path(
             image = Image.open(img_path)
     else:
         image = img_path
-    if image.mode in {'L', 'RGBA'}:
+    if image.mode != 'RGB':
         image = image.convert('RGB')
     return image
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Model or Dataset Support

# PR information

Fix the error caused by reading the file in CMYK format during the processing of multi-modal models.

FIX ISSUE: https://github.com/modelscope/swift/issues/677
