### PR TITLE
Fix loss scale

### DIFF
--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -421,10 +421,10 @@ class Template:
                                           'constant', 0)
                 labels[0] = F.pad(labels[0], (0, padding_len), 'constant',
                                   -100)
-        if loss_scale:
-            loss_scale[0] = F.pad(loss_scale[0],
-                                  (0, padding_to - labels[0].shape[-1]),
-                                  'constant', 0.)
+                if loss_scale:
+                    loss_scale[0] = F.pad(
+                        loss_scale[0], (0, padding_to - labels[0].shape[-1]),
+                        'constant', 0.)
 
         input_ids = pad_sequence(
             input_ids, batch_first=True, padding_value=tokenizer.pad_token_id)

--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -446,7 +446,7 @@ class Template:
             'attention_mask': attention_mask,
             'labels': labels,
         }
-        if loss_scale:
+        if loss_scale is not None:
             res['loss_scale'] = loss_scale
         return res
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Model or Dataset Support

# PR information

Fix training with loss_scale
```shell
TypeError: unsupported operand types for -:`NoneType` and `int`
```
This is because the wrong indent of the if case


## Experiment results

Paste your experiment result here(if needed).
