### PR TITLE
[Feature] Support sequence parallel with XTuner

### DIFF
--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Union
 import json
 import numpy as np
 import torch
+import torch.distributed as dist
 from modelscope import BitsAndBytesConfig, GenerationConfig
 from transformers import IntervalStrategy
 from transformers.integrations import is_deepspeed_zero3_enabled
@@ -25,6 +26,17 @@ from .utils import (TEMPLATE_MAPPING, LazyLLMDataset, SftArguments, Template,
                     get_model_tokenizer, get_template, get_time_info,
                     print_example, set_generation_config, sort_by_max_length,
                     stat_dataset)
+
+SUPPORT_XTUNER = False
+
+try:
+    from xtuner.parallel.sequence import *
+    # datasets is required in Xtuner
+    from datasets import Dataset
+    from xtuner.dataset.huggingface import pack_dataset
+    SUPPORT_XTUNER = True
+except ImportError:
+    pass
 
 logger = get_logger()
 
@@ -192,6 +204,25 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         dataset_info['train_dataset'] = stat_dataset(train_dataset)
         if val_dataset is not None:
             dataset_info['val_dataset'] = stat_dataset(val_dataset)
+        if args.pack_to_max_length:
+            assert SUPPORT_XTUNER, \
+                ('Please install XTuner first to pack dataset to `max_length`.'
+                 '`pip install -U \'xtuner[deepspeed]\'`')
+            if dist.get_rank() == 0:
+                ds = [i[0] for i in train_dataset.data]
+                train_dataset = Dataset.from_list(ds)
+                train_dataset = pack_dataset(
+                    train_dataset,
+                    max_length=args.max_length,
+                    use_varlen_attn=False,
+                    shuffle_before_pack=True,
+                    map_num_proc=16)
+                objects = [train_dataset]
+                train_dataset.save_to_disk('alpaca_pack')
+            else:
+                objects = [None]
+            dist.broadcast_object_list(objects, src=0)
+            train_dataset = objects[0]
     else:
         dataset_info = None
         td0, tkwargs0 = template.encode(train_dataset[0])
@@ -232,6 +263,7 @@ def llm_sft(args: SftArguments) -> Dict[str, Union[str, Any]]:
         trainer_kwargs['check_model'] = False
 
     trainer = Seq2SeqTrainer(
+        sequence_parallel_size=args.sequence_parallel_size,
         model=model,
         args=training_args,
         data_collator=data_collator,

--- a/swift/llm/tuner.py
+++ b/swift/llm/tuner.py
@@ -18,6 +18,15 @@ from swift.utils import (activate_model_parameters, freeze_model_parameters,
 from .utils import (SftArguments, find_all_linears, find_embedding, find_ln,
                     is_adapter)
 
+SUPPORT_XTUNER = False
+
+try:
+    from xtuner.model.modules.dispatch import dispatch_modules
+    from xtuner.parallel.sequence import *
+    SUPPORT_XTUNER = True
+except ImportError:
+    pass
+
 logger = get_logger()
 
 
@@ -185,6 +194,9 @@ def prepare_model(model, args: SftArguments):
             model.load_state_dict(state_dict, False)
             # release memory
             del state_dict
+        if SUPPORT_XTUNER:
+            dispatch_modules(model)
+            logger.info('Dispatch modules for sequence parallel.')
     else:
         raise ValueError(f'args.sft_type: {args.sft_type}')
 

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -487,6 +487,10 @@ class SftArguments(ArgumentsBase):
     # fsdp config file
     fsdp_config: Optional[str] = None
 
+    # xtuner config
+    sequence_parallel_size: int = 1
+    pack_to_max_length: bool = False
+
     def handle_dataset_mixture(self, train_dataset: HfDataset) -> None:
         if train_dataset is None:
             return train_dataset

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.distributed as dist
 from peft import PeftModel
 from torch import Tensor, nn
 from torch.nn import CrossEntropyLoss
@@ -14,7 +15,8 @@ from transformers import trainer
 from transformers.modeling_utils import unwrap_model
 from transformers.models.auto.modeling_auto import \
     MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
-from transformers.utils import is_peft_available
+from transformers.trainer_utils import seed_worker
+from transformers.utils import is_peft_available, is_torch_xla_available
 
 from swift.torchacc_utils import (ta_eval_dataloader, ta_test_dataloader,
                                   ta_train_dataloader)
@@ -28,6 +30,22 @@ try:
 except ImportError:
     from transformers.deepspeed import is_deepspeed_zero3_enabled
 
+if is_torch_xla_available():
+    import torch_xla.core.xla_model as xm
+
+SUPPORT_XTUNER = False
+
+try:
+    from xtuner.parallel.sequence import (init_sequence_parallel,
+                                          SequenceParallelSampler,
+                                          reduce_sequence_parallel_loss,
+                                          get_sequence_parallel_world_size,
+                                          get_sequence_parallel_group)
+    from mmengine.device.utils import get_max_cuda_memory
+    SUPPORT_XTUNER = True
+except ImportError:
+    pass
+
 
 class Trainer(PushToMsHubMixin, SwiftMixin, HfTrainer):
     pass
@@ -35,7 +53,7 @@ class Trainer(PushToMsHubMixin, SwiftMixin, HfTrainer):
 
 class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, sequence_parallel_size=1, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # performance
         self.perf: Dict[str, Any] = {
@@ -49,6 +67,9 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
                 self.model, 'get_trainable_parameters') else None,
         }
         self._acc = torch.tensor(0.).to(self.args.device)
+        if SUPPORT_XTUNER:
+            self.sequence_parallel_size = sequence_parallel_size
+            init_sequence_parallel(sequence_parallel_size)
 
     def train(self, *args, **kwargs) -> torch.Tensor:
         res = super().train(*args, **kwargs)
@@ -205,6 +226,7 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
         return loss.mean()
 
     def compute_loss(self, model, inputs, return_outputs=None):
+        assert 'labels' in inputs
         if not hasattr(self, '_custom_metrics'):
             self._custom_metrics = {}
 
@@ -240,9 +262,17 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
         else:
             loss = outputs['loss'] if isinstance(outputs, dict) else outputs[0]
 
-        preds = outputs.logits.argmax(dim=2)[..., :-1]
         if labels is None:
             labels = inputs['labels']
+
+        if SUPPORT_XTUNER:
+            # reduce loss for logging correctly
+            num_tokens = (labels != -100).sum()
+            loss = reduce_sequence_parallel_loss(loss, num_tokens,
+                                                 get_sequence_parallel_group())
+
+        preds = outputs.logits.argmax(dim=2)[..., :-1]
+
         labels = labels[..., 1:]
         masks = labels != -100
         acc_strategy = getattr(self.args, 'acc_strategy', 'token')
@@ -266,10 +296,90 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
                 'acc'] + acc / self.args.gradient_accumulation_steps
         return (loss, outputs) if return_outputs else loss
 
+    # Support logging cuda memory usage
+    # hacky: Override Trainer's private method
+    def _maybe_log_save_evaluate(self, tr_loss, grad_norm, model, trial, epoch,
+                                 ignore_keys_for_eval):
+        if self.control.should_log and self.state.global_step > self._globalstep_last_logged:
+            if is_torch_xla_available():
+                xm.mark_step()
+
+            logs: Dict[str, float] = {}
+
+            # all_gather + mean() to get average loss over all processes
+            tr_loss_scalar = self._nested_gather(tr_loss).mean().item()
+
+            # reset tr_loss to zero
+            tr_loss -= tr_loss
+
+            logs['loss'] = round(
+                tr_loss_scalar /
+                (self.state.global_step - self._globalstep_last_logged), 4)
+            if grad_norm is not None:
+                logs['grad_norm'] = grad_norm.detach().item() if isinstance(
+                    grad_norm, torch.Tensor) else grad_norm
+            logs['learning_rate'] = self._get_learning_rate()
+            logs['memory'] = get_max_cuda_memory()
+
+            self._total_loss_scalar += tr_loss_scalar
+            self._globalstep_last_logged = self.state.global_step
+            self.store_flos()
+
+            self.log(logs)
+
+        metrics = None
+        if self.control.should_evaluate:
+            metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
+            self._report_to_hp_search(trial, self.state.global_step, metrics)
+
+            # Run delayed LR scheduler now that metrics are populated
+            if isinstance(self.lr_scheduler,
+                          torch.optim.lr_scheduler.ReduceLROnPlateau):
+                metric_to_check = self.args.metric_for_best_model
+                if not metric_to_check.startswith('eval_'):
+                    metric_to_check = f'eval_{metric_to_check}'
+                self.lr_scheduler.step(metrics[metric_to_check])
+
+        if self.control.should_save:
+            self._save_checkpoint(model, trial, metrics=metrics)
+            self.control = self.callback_handler.on_save(
+                self.args, self.state, self.control)
+
     def get_train_dataloader(self):
 
         if not use_torchacc():
-            return super().get_train_dataloader()
+            # modified from HFTrainer.get_train_dataloader
+            # RandomSampler -> SequenceParallelSampler
+            if trainer.is_datasets_available():
+                import datasets
+            if self.train_dataset is None:
+                raise ValueError('Trainer: training requires a train_dataset.')
+
+            train_dataset = self.train_dataset
+            data_collator = self.data_collator
+            if trainer.is_datasets_available() and isinstance(
+                    train_dataset, datasets.Dataset):
+                train_dataset = self._remove_unused_columns(
+                    train_dataset, description='training')
+            else:
+                data_collator = self._get_collator_with_removed_columns(
+                    data_collator, description='training')
+
+            dataloader_params = {
+                'batch_size': self._train_batch_size,
+                'collate_fn': data_collator,
+                'num_workers': self.args.dataloader_num_workers,
+                'pin_memory': self.args.dataloader_pin_memory,
+                'persistent_workers': self.args.dataloader_persistent_workers,
+            }
+
+            if not isinstance(train_dataset, torch.utils.data.IterableDataset):
+                dataloader_params['sampler'] = SequenceParallelSampler(
+                    train_dataset, seed=1024)
+                dataloader_params['drop_last'] = self.args.dataloader_drop_last
+                dataloader_params['worker_init_fn'] = seed_worker
+
+            return DataLoader(train_dataset, **dataloader_params)
 
         else:
             if trainer.is_datasets_available():


### PR DESCRIPTION
Hi! `Sequence Parallel` and `Dataset Packing` are supported with XTuner in this pull request.

Sequence Parallel makes it possible to train large models with long sequence length using less training resources (GPU memory, GPU number).

Packing Dataset into max length can provide a substantial training speed increase (more than 10 times).

# Usage

### Step 1, Install XTuner

```
git clone https://github.com/InternLM/xtuner.git
cd xtuner
pip install -e '.[all]'
```
(XTuner will release next version as soon as posible)

### Step 2, Add the corresponding arguments 

1. Set `sequence_parallel_size` in arguments to enable sequence parallel strategy.

```
python swift/cli/sft.py --sequence_parallel_size 4 ...
```
2. Set `pack_to_max_length` to `true` to enable dataset packing.

```
python swift/cli/sft.py --pack_to_max_length true ...
```

# Performance

- Training 32k context length Llama3 8B without sequence parallel. Before training, we pack dataset to max length first. (ETA: 68 min, Almost OOM)

![image](https://github.com/modelscope/swift/assets/41630003/b29f7ead-ee38-4931-b412-a87b46b81185)

- Training 32k context length Llama3 8B with sequence parallel size 4. Before training, we pack dataset to max length first.(ETA: 48 min, Very close loss curve)

![image](https://github.com/modelscope/swift/assets/41630003/c3ff4505-2c70-41fb-af31-e0f3fc16750d)

- Training 32k context length Llama3 8B without sequence parallel and dataset packing. (ETA: More than 10 hours)

![image](https://github.com/modelscope/swift/assets/41630003/9a0e4573-3e47-4c62-b09d-b9fc8eb87d53)

# Notes

1. Currently, only full finetune with sequence parallel is supported.
2. Currently, dataset packing can not be used with `lazy_tokenize=True`