### PR TITLE
fix xcomposer device_map

### DIFF
--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2619,13 +2619,13 @@ def get_model_tokenizer_internlm_xcomposer2(model_dir: str,
 
         model_cls = model.__class__
         if not hasattr(model_cls, '__old_encode_img'):  # avoid double patching
-            encode_img = model_cls.encode_img
-            model_cls.__old_encode_img = encode_img
+            model_cls.__old_encode_img = model_cls.encode_img
 
             def _new_encode_img(self, image):
                 if image is None:
                     return None
                 if isinstance(image, str):
+                    from PIL import Image
                     image = Image.open(image).convert('RGB')
                     image = self.vis_processor(image).unsqueeze(0).to(
                         self.device)

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2619,8 +2619,8 @@ def get_model_tokenizer_internlm_xcomposer2(model_dir: str,
 
         model_cls = model.__class__
         if not hasattr(model_cls, '__old_encode_img'):  # avoid double patching
-            encode_img = model.__class__.encode_img
-            model.__class__.__old_encode_img = encode_img
+            encode_img = model_cls.encode_img
+            model_cls.__old_encode_img = encode_img
 
             def _new_encode_img(self, image):
                 if image is None:
@@ -2635,7 +2635,7 @@ def get_model_tokenizer_internlm_xcomposer2(model_dir: str,
                 img_embeds, atts_img, img_target = self.img2emb(image)
                 return img_embeds.to(device=self.device)  # FIX device_map
 
-            model.__class__.encode_img = _new_encode_img
+            model_cls.encode_img = _new_encode_img
 
     return model, tokenizer
 

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2621,17 +2621,20 @@ def get_model_tokenizer_internlm_xcomposer2(model_dir: str,
         if not hasattr(model_cls, '__old_encode_img'):  # avoid double patching
             encode_img = model.__class__.encode_img
             model.__class__.__old_encode_img = encode_img
+
             def _new_encode_img(self, image):
                 if image is None:
                     return None
                 if isinstance(image, str):
                     image = Image.open(image).convert('RGB')
-                    image = self.vis_processor(image).unsqueeze(0).to(self.device)
+                    image = self.vis_processor(image).unsqueeze(0).to(
+                        self.device)
                 else:
                     assert isinstance(image, torch.Tensor)
 
                 img_embeds, atts_img, img_target = self.img2emb(image)
-                return img_embeds.to(device=self.device)  # FIX device_map == 2
+                return img_embeds.to(device=self.device)  # FIX device_map
+
             model.__class__.encode_img = _new_encode_img
 
     return model, tokenizer


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## PR Info

FIX ISSUE: https://github.com/modelscope/swift/issues/837

device_map:
```sh
# device_map2
CUDA_VISIBLE_DEVICES=0,1 swift sft \
    --model_type internlm-xcomposer2-7b-chat \
    --dataset coco-mini-en \

# device_map4
CUDA_VISIBLE_DEVICES=0,1,2,3 swift sft \
    --model_type internlm-xcomposer2-7b-chat \
    --dataset coco-mini-en \
```


zero2:
```sh
CUDA_VISIBLE_DEVICES=0,1,2,3 NPROC_PER_NODE=4 swift sft \
    --model_type internlm-xcomposer2-7b-chat \
    --dataset coco-mini-en \
    --deepspeed default-zero2
```


