### PR TITLE
fix dataset info deepcopy

### DIFF
--- a/docs/source/LLM/命令行参数.md
+++ b/docs/source/LLM/命令行参数.md
@@ -205,7 +205,7 @@ dpo参数继承了sft参数, 除此之外增加了以下参数:
 - `--dtype`: 默认值为`'AUTO`, 具体的参数介绍可以在`sft.sh命令行参数`中查看.
 - `--dataset`: 默认值为`[]`, 具体的参数介绍可以在`sft.sh命令行参数`中查看.
 - `--dataset_seed`: 默认值为`42`, 具体的参数介绍可以在`sft.sh命令行参数`中查看.
-- `--dataset_test_ratio`: 默认值为`0.01`, 具体的参数介绍可以在`sft.sh命令行参数`中查看.
+- `--dataset_test_ratio`: 默认值为`None`, 如果`--load_dataset_config true`则使用训练时的dataset_test_ratio, 否则设置为1. 具体的参数介绍可以在`sft.sh命令行参数`中查看.
 - `--show_dataset_sample`: 表示想要评估和展示的验证集的数量, 默认值为`10`.
 - `--system`: 默认值为`None`. 具体的参数介绍可以在`sft.sh命令行参数`中查看.
 - `--max_length`: 默认值为`-1`. 具体的参数介绍可以在`sft.sh命令行参数`中查看.

--- a/docs/source_en/LLM/Command-line-parameters.md
+++ b/docs/source_en/LLM/Command-line-parameters.md
@@ -206,7 +206,7 @@ dpo parameters inherit from sft parameters, with the following added parameters:
 - `--dtype`: Default is `'AUTO`, see `sft.sh command line arguments` for parameter details.
 - `--dataset`: Default is `[]`, see `sft.sh command line arguments` for parameter details.
 - `--dataset_seed`: Default is `42`, see `sft.sh command line arguments` for parameter details.
-- `--dataset_test_ratio`: Default is `0.01`, see `sft.sh command line arguments` for parameter details.
+`--dataset_test_ratio`: Default value is `None`, if `--load_dataset_config true` is set, then use the dataset_test_ratio from training, else set it to 1. For specific parameter details, refer to the `sft.sh command line arguments`.
 - `--show_dataset_sample`: Represents number of validation set samples to evaluate and display, default is `10`.
 - `--system`: Default is `None`. See `sft.sh command line arguments` for parameter details.
 - `--max_length`: Default is `-1`. See `sft.sh command line arguments` for parameter details.

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -1076,7 +1076,7 @@ class InferArguments(ArgumentsBase):
                 'model_name', 'model_author', 'train_dataset_sample', 'val_dataset_sample'
             ]
         for key in imported_keys:
-        value = getattr(self, key)
+            value = getattr(self, key)
             if key == 'dataset' and len(value) > 0:
                 continue
             if key == 'dataset_test_ratio' and value is not None:

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -916,7 +916,7 @@ class InferArguments(ArgumentsBase):
     dataset: List[str] = field(
         default_factory=list, metadata={'help': f'dataset choices: {list(DATASET_MAPPING.keys())}'})
     dataset_seed: int = 42
-    dataset_test_ratio: float = 0.01
+    dataset_test_ratio: Optional[float] = None
     show_dataset_sample: int = 10
     save_result: bool = True
     system: Optional[str] = None
@@ -998,6 +998,8 @@ class InferArguments(ArgumentsBase):
 
         self.torch_dtype, _, _ = self.select_dtype()
         self.prepare_template()
+        if self.dataset_test_ratio is None:
+            self.dataset_test_ratio = 1
         if self.eval_human is None:
             if not len(self.dataset) > 0:
                 self.eval_human = True
@@ -1074,7 +1076,10 @@ class InferArguments(ArgumentsBase):
                 'model_name', 'model_author', 'train_dataset_sample', 'val_dataset_sample'
             ]
         for key in imported_keys:
-            if key == 'dataset' and len(getattr(self, key)) > 0:
+        value = getattr(self, key)
+            if key == 'dataset' and len(value) > 0:
+                continue
+            if key == 'dataset_test_ratio' and value is not None:
                 continue
             setattr(self, key, sft_args.get(key))
 

--- a/swift/llm/utils/dataset.py
+++ b/swift/llm/utils/dataset.py
@@ -3,6 +3,7 @@ import ast
 import itertools
 import os
 import re
+from copy import deepcopy
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -1342,7 +1343,7 @@ def register_dataset_info_file(dataset_info_path: Optional[str] = None) -> None:
             base_dir = None
     else:
         assert isinstance(dataset_info_path, dict)
-        dataset_info = dataset_info_path
+        dataset_info = deepcopy(dataset_info_path)
         dataset_info_path = list(dataset_info.keys())
         base_dir = None
     for dataset_name, d_info in dataset_info.items():

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -223,7 +223,7 @@ class TextGenerationPreprocessor:
 
 class ClsPreprocessor:
 
-    def __init__(self, labels: List[str], task_name: str, is_pair_seq: bool) -> None:
+    def __init__(self, labels: List[str], task_name: str, is_pair_seq: bool = False) -> None:
         self.labels = labels
         category = ', '.join(labels)
         if is_pair_seq:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

1. dataset_info如果传入dict, 则进行deepcopy, 防止对传入数值产生影响.
2. swift infer中dataset_test_ratio的默认值改为None. 在是否load_dataset_config情况下使用不同的行为.

English:
1. If dataset_info is passed as a dict, perform a deepcopy to prevent affecting the passed values.
2. The default value of dataset_test_ratio in swift infer is changed to None, with different behavior depending on whether load_dataset_config is used or not.
