### PR TITLE
fix swift cli exit code if subprocess is failed

### DIFF
--- a/swift/cli/main.py
+++ b/swift/cli/main.py
@@ -61,7 +61,9 @@ def cli_main() -> None:
     else:
         args = ['torchrun', *torchrun_args, file_path, *argv]
     print(f"run sh: `{' '.join(args)}`", flush=True)
-    subprocess.run(args)
+    result = subprocess.run(args)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Job executed on remote machine relies on the exit code of the command to determine if the job is successful or a failure. Currently, the swift cli always returns an exit code of 0, which leads to a situation where even if the training job actually fails, it is still considered successful at the job level.

## Experiment results

before 
![image](https://github.com/modelscope/swift/assets/8534560/62543613-ba7a-46df-b074-60c1f4c3bf9f)


current PR branch test result:

![image](https://github.com/modelscope/swift/assets/8534560/e5fb414a-1c92-4335-8a2e-61af768c5ee2)

