### PR TITLE
修复cpu环境下 module 'torch._C' has no attribute '_cuda_resetPeakMemoryStats 的错误

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -513,7 +513,8 @@ class SwiftMixin:
         mem = sum([float(mem) / 1024 / 1024 / 1024 for mem in mems])
         if self.max_memory < mem:
             self.max_memory = mem
-        torch.cuda.reset_peak_memory_stats()
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
         return mem
 
     def _maybe_log_save_evaluate(self, tr_loss, *args, **kwargs):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
cpu环境下 无cuda，但是调用了get_max_cuda_memory方法，导致报错
