### PR TITLE
fix Internvl-int8 sft bug

### DIFF
--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -27,7 +27,7 @@ from transformers.utils.versions import require_version
 from swift import get_logger
 from swift.utils import get_dist_setting, safe_ddp_context, subprocess_run, use_torchacc
 from .template import TemplateType
-from .utils import get_max_model_len, is_unsloth_available, pad_tokenizer_vocabulary_to_multiple_of
+from .utils import get_max_model_len, is_unsloth_available
 
 logger = get_logger()
 
@@ -2590,18 +2590,14 @@ def fix_internvl_inplace_bug(model) -> None:
 
 
 def patch_bnb_matmulltstate():
-    import bitsandbytes.autograd._functions
-    if not hasattr(bitsandbytes.autograd._functions, 'OldMatmulLtState'):
-        from dataclasses import dataclass, field
-        old_MatmulLtState = bitsandbytes.autograd._functions.MatmulLtState
-
-        @dataclass
+    import bitsandbytes
+    if not hasattr(bitsandbytes, 'OldMatmulLtState'):
+        old_MatmulLtState = bitsandbytes.MatmulLtState
         class PatchedMatmulLtState(old_MatmulLtState):
             force_no_igemmlt: bool = True
 
-        bitsandbytes.autograd._functions.MatmulLtState = PatchedMatmulLtState
-        bitsandbytes.autograd._functions.OldMatmulLtState = old_MatmulLtState
-
+        bitsandbytes.MatmulLtState = PatchedMatmulLtState
+        bitsandbytes.OldMatmulLtState = old_MatmulLtState
 
 @register_model(
     ModelType.internvl_chat_v1_5,

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2554,9 +2554,9 @@ def get_model_tokenizer_deepseek2(model_dir: str,
     model_config._attn_implementation = 'flash_attention_2' if use_flash_attn else 'eager'
     model, tokenizer = get_model_tokenizer_from_repo(
         model_dir, torch_dtype, model_kwargs, load_model, model_config=model_config, **kwargs)
-    model.generation_config.pad_token_id = model.generation_config.eos_token_id
     if model is not None:
         # fix dtype bug
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
         mlp_cls = model.model.layers[1].mlp.__class__
         for module in model.modules():
             if isinstance(module, mlp_cls):

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2723,11 +2723,11 @@ def get_model_tokenizer_internvl(model_dir: str,
             pad_tokenizer_vocabulary_to_multiple_of(tokenizer)
 
     if model is not None:
-        new_get = MethodType(_new_get_resized_lm_head, model.language_model)
-        if hasattr(model.language_model, '_old_get'):  # device_map
-            model.language_model._old_get_resized_lm_head = new_get
-        else:
-            model.language_model.get_resized_lm_head = new_get
+        model.language_model.get_resized_lm_head = MethodType(_new_get_resized_lm_head, model.language_model)
+        # if hasattr(model.language_model, '_old_get'):  # device_map
+        #     model.language_model._old_get_resized_lm_head = new_get
+        # else:
+        #     model.language_model.get_resized_lm_head = new_get
         model.language_model.resize_token_embeddings(len(tokenizer))
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])
         fix_internvl_inplace_bug(model)

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2722,9 +2722,13 @@ def get_model_tokenizer_internvl(model_dir: str,
     use_flash_attn = kwargs.pop('use_flash_attn', False)
     model_config.vision_config.use_flash_attn = use_flash_attn
     model_config.llm_config.attn_implementation = 'flash_attention_2' if use_flash_attn else 'eager'
-    use_bnb = getattr(model_config, 'quantization_config', None) == 'bitsandbytes'
-    if 'quantization_config' in model_kwargs:
-        use_bnb = model_kwargs['quantization_config'].get('quant_method') == 'bitandbytes' or use_bnb
+    model_quant_config = getattr(model_config, 'quantization_config', None)
+
+    use_bnb = False
+    if model_quant_config is not None:
+        use_bnb = getattr(model_quant_config, 'quant_method', None) == 'bitsandbytes'
+    # if 'quantization_config' in model_kwargs:
+    #     use_bnb = model_kwargs['quantization_config'].get('quant_method') == 'bitandbytes' or use_bnb
     # if model_bnb_quant_config
     #     if model_quant_config['quant_method'] == 'bitsandbytes' or kwargs_quant_method == 'bitandbytes':
     #         # quant_config.llm_int8_skip_modules = ['lm_head']

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2638,6 +2638,7 @@ def get_model_tokenizer_internvl(model_dir: str,
         **kwargs)
 
     if model is not None:
+        model.resize_token_embeddings(len(tokenizer))
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])
         fix_internvl_inplace_bug(model)
         if not hasattr(model, '__old_forward'):  # Avoid double patching

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2722,15 +2722,13 @@ def get_model_tokenizer_internvl(model_dir: str,
     use_flash_attn = kwargs.pop('use_flash_attn', False)
     model_config.vision_config.use_flash_attn = use_flash_attn
     model_config.llm_config.attn_implementation = 'flash_attention_2' if use_flash_attn else 'eager'
-    use_bnb = False
-    model_quant_config = getattr(model_config, 'quantization_config', None)
-    kwargs_quant_method = None
+    use_bnb = getattr(model_config, 'quantization_config', None) == 'bitsandbytes'
     if 'quantization_config' in model_kwargs:
-        kwargs_quant_method = model_kwargs['quantization_config'].get('quant_method')
-    if model_quant_config is not None:
-        if isinstance(model_quant_config, BitsAndBytesConfig) or kwargs_quant_method == 'bitandbytes':
-            # quant_config.llm_int8_skip_modules = ['lm_head']
-            use_bnb = True
+        use_bnb = model_kwargs['quantization_config'].get('quant_method') == 'bitandbytes' or use_bnb
+    # if model_bnb_quant_config
+    #     if model_quant_config['quant_method'] == 'bitsandbytes' or kwargs_quant_method == 'bitandbytes':
+    #         # quant_config.llm_int8_skip_modules = ['lm_head']
+    #         use_bnb = True
 
     model, tokenizer = get_model_tokenizer_from_repo(
         model_dir,

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2768,7 +2768,7 @@ def get_model_tokenizer_internvl(model_dir: str,
 
             @wraps(extract_feature)
             def _new_extract_feature(pixel_values):
-                return extract_feature(pixel_values).to(pixel_values.device)
+                return extract_feature(pixel_values).to(pixel_values.device).to(pixel_values.dtype)
 
             model.extract_feature = _new_extract_feature
 

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2728,6 +2728,7 @@ def get_model_tokenizer_internvl(model_dir: str,
             model.language_model._old_get_resized_lm_head = new_get
         else:
             model.language_model.get_resized_lm_head = new_get
+        model.language_model.resize_token_embeddings(len(tokenizer))
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])
         fix_internvl_inplace_bug(model)
         if not hasattr(model, '__old_forward'):  # Avoid double patching

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -18,10 +18,8 @@ from modelscope.hub.utils.utils import get_cache_dir
 from packaging import version
 from torch import Tensor
 from torch import dtype as Dtype
-from torch import nn
 from transformers import PretrainedConfig, PreTrainedModel, PreTrainedTokenizerBase
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
-from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from transformers.utils import strtobool
 from transformers.utils.versions import require_version
@@ -29,7 +27,7 @@ from transformers.utils.versions import require_version
 from swift import get_logger
 from swift.utils import get_dist_setting, safe_ddp_context, subprocess_run, use_torchacc
 from .template import TemplateType
-from .utils import get_max_model_len, is_unsloth_available, pad_tokenizer_vocabulary_to_multiple_of
+from .utils import get_max_model_len, is_unsloth_available
 
 logger = get_logger()
 
@@ -2557,8 +2555,8 @@ def get_model_tokenizer_deepseek2(model_dir: str,
     model, tokenizer = get_model_tokenizer_from_repo(
         model_dir, torch_dtype, model_kwargs, load_model, model_config=model_config, **kwargs)
     if model is not None:
-        # fix dtype bug
         model.generation_config.pad_token_id = model.generation_config.eos_token_id
+        # fix dtype bug
         mlp_cls = model.model.layers[1].mlp.__class__
         for module in model.modules():
             if isinstance(module, mlp_cls):

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -27,7 +27,7 @@ from transformers.utils.versions import require_version
 from swift import get_logger
 from swift.utils import get_dist_setting, safe_ddp_context, subprocess_run, use_torchacc
 from .template import TemplateType
-from .utils import get_max_model_len, is_unsloth_available
+from .utils import get_max_model_len, is_unsloth_available, pad_tokenizer_vocabulary_to_multiple_of
 
 logger = get_logger()
 
@@ -2612,22 +2612,11 @@ def get_model_tokenizer_internvl(model_dir: str,
                                  model_kwargs: Dict[str, Any],
                                  load_model: bool = True,
                                  **kwargs):
-    if (model_kwargs.get('quantization_config') is not None
-            and isinstance(model_kwargs['quantization_config'], BitsAndBytesConfig)):
-        # https://github.com/pytorch/pytorch/issues/58969
-        model_kwargs['quantization_config'].llm_int8_skip_modules = ['lm_head', 'attn_pool.attn']
-        _TransformerBlock = get_class_from_dynamic_module('visual.TransformerBlock', model_dir)
-
-        def _get_cast_dtype(self) -> torch.dtype:
-            return self.resblocks[0].ln_1.weight.dtype
-
-        _TransformerBlock.__old_get_cast_dtype = _TransformerBlock.get_cast_dtype
-        _TransformerBlock.get_cast_dtype = _get_cast_dtype
-    
     model_config = AutoConfig.from_pretrained(model_dir, trust_remote_code=True)
     use_flash_attn = kwargs.pop('use_flash_attn', False)
     model_config.vision_config.use_flash_attn = use_flash_attn
     model_config.llm_config.attn_implementation = 'flash_attention_2' if use_flash_attn else 'eager'
+
     model, tokenizer = get_model_tokenizer_from_repo(
         model_dir,
         torch_dtype,
@@ -2636,9 +2625,12 @@ def get_model_tokenizer_internvl(model_dir: str,
         model_config=model_config,
         automodel_class=AutoModel,
         **kwargs)
-
+    if model_kwargs.get('quantization_config') is None or not isinstance(model_kwargs['quantization_config'],
+                                                                         BitsAndBytesConfig):
+        pad_tokenizer_vocabulary_to_multiple_of(tokenizer)
+    
     if model is not None:
-        model.resize_token_embeddings(len(tokenizer))
+        model.language_model.resize_token_embeddings(len(tokenizer))
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])
         fix_internvl_inplace_bug(model)
         if not hasattr(model, '__old_forward'):  # Avoid double patching

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2622,6 +2622,11 @@ def get_model_tokenizer_internvl(model_dir: str,
                                  model_kwargs: Dict[str, Any],
                                  load_model: bool = True,
                                  **kwargs):
+    if model_kwargs.get('quantization_config') is None or not isinstance(model_kwargs['quantization_config'],
+                                                                         BitsAndBytesConfig):
+        # patch: backward shape mismatch bug
+        patch_bnb_matmulltstate()
+        
     model_config = AutoConfig.from_pretrained(model_dir, trust_remote_code=True)
     use_flash_attn = kwargs.pop('use_flash_attn', False)
     model_config.vision_config.use_flash_attn = use_flash_attn
@@ -2635,11 +2640,6 @@ def get_model_tokenizer_internvl(model_dir: str,
         model_config=model_config,
         automodel_class=AutoModel,
         **kwargs)
-
-    if model_kwargs.get('quantization_config') is None or not isinstance(model_kwargs['quantization_config'],
-                                                                         BitsAndBytesConfig):
-        # patch: backward shape mismatch bug
-        patch_bnb_matmulltstate()
 
     if model is not None:
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2615,72 +2615,69 @@ def patch_resize_embeddings(model) -> None:
         model.get_resized_lm_head = get_resized_lm_head
         model._old_get_resized_lm_head = old_get_resized_lm_head
 
-def patch_get_resized_lm_head(model) -> None:
-    if hasattr(model, '_old_get_resized_lm_head'):
-        return
-    from torch import nn
-    from transformers.integrations import is_deepspeed_zero3_enabled
+from torch import nn
+from transformers.integrations import is_deepspeed_zero3_enabled
+try:
     from bitsandbytes.nn.modules import Linear8bitLt
-    def _new_get_resized_lm_head(
-        self, old_lm_head: nn.Linear, new_num_tokens: Optional[int] = None, transposed: Optional[bool] = False
-    ) -> nn.Linear:
-        if new_num_tokens is None:
-            return old_lm_head
+except:
+    pass
+def _new_get_resized_lm_head(
+    self, old_lm_head: nn.Linear, new_num_tokens: Optional[int] = None, transposed: Optional[bool] = False
+) -> nn.Linear:    
+    if new_num_tokens is None:
+        return old_lm_head
 
-        is_quantized = hasattr(self, "hf_quantizer") and self.hf_quantizer is not None
-        if is_deepspeed_zero3_enabled() and not is_quantized:
-            import deepspeed
+    is_quantized = hasattr(self, "hf_quantizer") and self.hf_quantizer is not None
+    if is_deepspeed_zero3_enabled() and not is_quantized:
+        import deepspeed
 
-            with deepspeed.zero.GatheredParameters(old_lm_head.weight, modifier_rank=None):
-                old_num_tokens, old_lm_head_dim = (
-                    old_lm_head.weight.size() if not transposed else old_lm_head.weight.t().size()
-                )
-        else:
+        with deepspeed.zero.GatheredParameters(old_lm_head.weight, modifier_rank=None):
             old_num_tokens, old_lm_head_dim = (
                 old_lm_head.weight.size() if not transposed else old_lm_head.weight.t().size()
             )
-
-        if old_num_tokens == new_num_tokens and not is_deepspeed_zero3_enabled():
-            return old_lm_head
-
-        if not isinstance(old_lm_head, nn.Linear):
-            raise TypeError(
-                f"Old language model head is of type {type(old_lm_head)}, which is not an instance of {nn.Linear}. You"
-                " should either use a different resize function or make sure that `old_lm_head` are an instance of"
-                f" {nn.Linear}."
-            )
-
-        new_lm_head_shape = (old_lm_head_dim, new_num_tokens) if not transposed else (new_num_tokens, old_lm_head_dim)
-        has_new_lm_head_bias = old_lm_head.bias is not None
-
-        new_lm_head = Linear8bitLt(
-            *new_lm_head_shape,
-            bias=has_new_lm_head_bias,
-            device=old_lm_head.weight.device,
-            dtype=old_lm_head.weight.dtype,
+    else:
+        old_num_tokens, old_lm_head_dim = (
+            old_lm_head.weight.size() if not transposed else old_lm_head.weight.t().size()
         )
 
-        self._init_weights(new_lm_head)
+    if old_num_tokens == new_num_tokens and not is_deepspeed_zero3_enabled():
+        return old_lm_head
 
-        num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
+    if not isinstance(old_lm_head, nn.Linear):
+        raise TypeError(
+            f"Old language model head is of type {type(old_lm_head)}, which is not an instance of {nn.Linear}. You"
+            " should either use a different resize function or make sure that `old_lm_head` are an instance of"
+            f" {nn.Linear}."
+        )
 
-        if is_deepspeed_zero3_enabled() and not is_quantized:
-            import deepspeed
+    new_lm_head_shape = (old_lm_head_dim, new_num_tokens) if not transposed else (new_num_tokens, old_lm_head_dim)
+    has_new_lm_head_bias = old_lm_head.bias is not None
 
-            params = [old_lm_head.weight, old_lm_head.bias, new_lm_head.weight, new_lm_head.bias]
-            with deepspeed.zero.GatheredParameters(params, modifier_rank=0):
-                self._copy_lm_head_original_to_resized(
-                    new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
-                )
-        else:
+    new_lm_head = Linear8bitLt(
+        *new_lm_head_shape,
+        bias=has_new_lm_head_bias,
+        device=old_lm_head.weight.device,
+        dtype=old_lm_head.weight.dtype,
+    )
+
+    self._init_weights(new_lm_head)
+
+    num_tokens_to_copy = min(old_num_tokens, new_num_tokens)
+
+    if is_deepspeed_zero3_enabled() and not is_quantized:
+        import deepspeed
+
+        params = [old_lm_head.weight, old_lm_head.bias, new_lm_head.weight, new_lm_head.bias]
+        with deepspeed.zero.GatheredParameters(params, modifier_rank=0):
             self._copy_lm_head_original_to_resized(
                 new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
             )
+    else:
+        self._copy_lm_head_original_to_resized(
+            new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
+        )
 
-        return new_lm_head
-    old_get = model._get_resized_lm_head
-    model._get_resized_lm_head = _new_get_resized_lm_head
-    model._old_get_resized_lm_head = old_get
+    return new_lm_head
 
 @register_model(
     ModelType.internvl_chat_v1_5,
@@ -2722,11 +2719,15 @@ def get_model_tokenizer_internvl(model_dir: str,
     if model_kwargs.get('quantization_config') is None or not isinstance(model_kwargs['quantization_config'],
                                                                          BitsAndBytesConfig):
         # patch: backward shape mismatch bug
-        pad_tokenizer_vocabulary_to_multiple_of(tokenizer)
-        patch_get_resized_lm_head(model.language_model)
-        model.language_model.resize_token_embeddings(len(tokenizer))
+        if tokenizer is not None:
+            pad_tokenizer_vocabulary_to_multiple_of(tokenizer)
 
     if model is not None:
+        new_get = MethodType(_new_get_resized_lm_head, model.language_model)
+        if hasattr(model.language_model, '_old_get'):  # device_map
+            model.language_model._old_get_resized_lm_head = new_get
+        else:
+            model.language_model.get_resized_lm_head = new_get
         _use_submodel_func(model, 'language_model', ['get_input_embeddings'])
         fix_internvl_inplace_bug(model)
         if not hasattr(model, '__old_forward'):  # Avoid double patching

--- a/swift/llm/utils/model.py
+++ b/swift/llm/utils/model.py
@@ -2639,7 +2639,7 @@ def get_model_tokenizer_internvl(model_dir: str,
     if model_kwargs.get('quantization_config') is None or not isinstance(model_kwargs['quantization_config'],
                                                                          BitsAndBytesConfig):
         # patch: backward shape mismatch bug
-        patch_bnb_matmulltstate(tokenizer)
+        pad_tokenizer_vocabulary_to_multiple_of(tokenizer)
         model.language_model.resize_token_embeddings(len(tokenizer))
 
     if model is not None:

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -905,15 +905,3 @@ if is_ddp_plus_mp() or use_torchacc():
     trainer.Accelerator.__init__ = (lambda self, device_placement=False, *args, **kwargs: _old_accelerator_init(
         self, device_placement=device_placement, *args, **kwargs))
     trainer.Accelerator.verify_device_map = lambda *args, **kwargs: False
-
-
-def pad_tokenizer_vocabulary_to_multiple_of(tokenizer, multiple_of: int = 32):
-    vocab_size = len(tokenizer)
-    next_multiple = ((vocab_size + multiple_of - 1) // multiple_of) * multiple_of
-    num_padding_tokens = next_multiple - vocab_size
-
-    if num_padding_tokens > 0:
-        padding_tokens = [f'[SWIFT_PAD{i}]' for i in range(vocab_size, next_multiple)]
-        tokenizer.add_tokens(padding_tokens)
-
-    return tokenizer

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -905,3 +905,15 @@ if is_ddp_plus_mp() or use_torchacc():
     trainer.Accelerator.__init__ = (lambda self, device_placement=False, *args, **kwargs: _old_accelerator_init(
         self, device_placement=device_placement, *args, **kwargs))
     trainer.Accelerator.verify_device_map = lambda *args, **kwargs: False
+
+
+def pad_tokenizer_vocabulary_to_multiple_of(tokenizer, multiple_of: int = 32):
+    vocab_size = len(tokenizer)
+    next_multiple = ((vocab_size + multiple_of - 1) // multiple_of) * multiple_of
+    num_padding_tokens = next_multiple - vocab_size
+
+    if num_padding_tokens > 0:
+        padding_tokens = [f'[SWIFT_PAD{i}]' for i in range(vocab_size, next_multiple)]
+        tokenizer.add_tokens(padding_tokens)
+
+    return tokenizer

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -911,10 +911,9 @@ def pad_tokenizer_vocabulary_to_multiple_of(tokenizer, multiple_of: int = 32):
     vocab_size = len(tokenizer)
     next_multiple = ((vocab_size + multiple_of - 1) // multiple_of) * multiple_of
     num_padding_tokens = next_multiple - vocab_size
-    
+
     if num_padding_tokens > 0:
-        # 添加指定数量的填充token
         padding_tokens = [f'[SWIFT_PAD{i}]' for i in range(vocab_size, next_multiple)]
         tokenizer.add_tokens(padding_tokens)
-    
+
     return tokenizer

--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -905,3 +905,16 @@ if is_ddp_plus_mp() or use_torchacc():
     trainer.Accelerator.__init__ = (lambda self, device_placement=False, *args, **kwargs: _old_accelerator_init(
         self, device_placement=device_placement, *args, **kwargs))
     trainer.Accelerator.verify_device_map = lambda *args, **kwargs: False
+
+
+def pad_tokenizer_vocabulary_to_multiple_of(tokenizer, multiple_of: int = 32):
+    vocab_size = len(tokenizer)
+    next_multiple = ((vocab_size + multiple_of - 1) // multiple_of) * multiple_of
+    num_padding_tokens = next_multiple - vocab_size
+    
+    if num_padding_tokens > 0:
+        # 添加指定数量的填充token
+        padding_tokens = [f'[SWIFT_PAD{i}]' for i in range(vocab_size, next_multiple)]
+        tokenizer.add_tokens(padding_tokens)
+    
+    return tokenizer


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

fix bug described in https://github.com/OpenGVLab/InternVL/issues/129
```
bitsandbytes/autograd/_functions.py", line 479, in backward
    .mul_(state.SCB.unsqueeze(1).mul(1.0 / 127.0))
RuntimeError: The size of tensor a (92576) must match the size of tensor b (92553) at non-singleton dimension 0
```