### PR TITLE
在argument.py添加hccl参数，用于NPU环境下训练使用

### DIFF
--- a/swift/aigc/utils/argument.py
+++ b/swift/aigc/utils/argument.py
@@ -25,7 +25,7 @@ class AnimateDiffArguments:
     sft_type: str = field(default='lora', metadata={'choices': ['lora', 'full']})
 
     output_dir: str = 'output'
-    ddp_backend: str = field(default='nccl', metadata={'choices': ['nccl', 'gloo', 'mpi', 'ccl']})
+    ddp_backend: str = field(default='nccl', metadata={'choices': ['nccl', 'gloo', 'mpi', 'ccl', 'hccl']})
 
     seed: int = 42
 

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -442,7 +442,7 @@ class SftArguments(ArgumentsBase):
         default='AUTO', metadata={'help': f"template_type choices: {list(TEMPLATE_MAPPING.keys()) + ['AUTO']}"})
     output_dir: str = 'output'
     add_output_dir_suffix: Optional[bool] = None
-    ddp_backend: Optional[Literal['nccl', 'gloo', 'mpi', 'ccl']] = None
+    ddp_backend: Optional[Literal['nccl', 'gloo', 'mpi', 'ccl', 'hccl']] = None
     ddp_find_unused_parameters: Optional[bool] = None
     ddp_broadcast_buffers: Optional[bool] = None
 


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

NPU机器下训练，使用torch-npu结合torch会报无法找到nccl、ccl等相关错误信息，需要指定hccl，因此再此加入hccl选项，可在NPU上进行正常的训练

## Experiment results

NPU机器训练测试通过
