### PR TITLE
Fix glm4v dataloader

### DIFF
--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -950,6 +950,13 @@ class GLM4VTemplate(GLMTemplate):
         inputs['labels'] = labels
         return inputs, {}
 
+    def data_collator(self, batch: List[Dict[str, Any]], padding_to: Optional[int] = None) -> Dict[str, Any]:
+        res = super().data_collator(batch, padding_to)
+        images = [b['images'] for b in batch if 'images' in b]
+        if images:
+            res['images'] = torch.concat(images)
+        return res
+
 
 register_template(TemplateType.glm4v, GLM4VTemplate(), infer_media_type='dialogue', lazy_tokenize=True)
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

The current `GLM4VTemplate` does not have a `data_collator` function, which results in calling the `data_collator` function of the base class `Template`:
```python
res = {
    'input_ids': input_ids,
    'attention_mask': attention_mask,
    'labels': labels,
}
if loss_scale is not None:
    res['loss_scale'] = loss_scale
return res
```
The `res` returned by the base class function does not include `images`, causing the training of `glm4v` to only train on pure text.