### PR TITLE
Fix dataset concatenation

### DIFF
--- a/swift/llm/utils/dataset.py
+++ b/swift/llm/utils/dataset.py
@@ -2262,6 +2262,7 @@ def get_dataset(
             if 'history' in ds.features:
                 features = ds.features.copy()
                 features['_history'] = Sequence(feature=Sequence(feature=Value(dtype='string')))
+            if 'system' in ds.features:
                 features['_system'] = Value(dtype='string')
             ds = ds.map(_reduce_column, load_from_cache_file=False, features=features)
             if 'history' in ds.features:

--- a/swift/llm/utils/dataset.py
+++ b/swift/llm/utils/dataset.py
@@ -11,7 +11,7 @@ import json
 import numpy as np
 import pandas as pd
 from datasets import Dataset as HfDataset
-from datasets import concatenate_datasets
+from datasets import Sequence, Value, concatenate_datasets
 from datasets import load_dataset as load_hf_dataset
 from numpy.random import RandomState
 from pandas import DataFrame
@@ -2246,7 +2246,29 @@ def get_dataset(
                 res['query'] = np.random.choice(row['query'])
             if 'response' in row and isinstance(row['response'], (list, tuple)):
                 res['response'] = np.random.choice(row['response'])
+            if 'rejected_response' in row and isinstance(row['rejected_response'], (list, tuple)):
+                res['rejected_response'] = np.random.choice(row['rejected_response'])
+            if 'history' in row:
+                if not row['history']:
+                    res['_history'] = None
+                else:
+                    res['_history'] = row['history']
+            if 'system' in row:
+                res['_system'] = row['system']
             return res
+
+        def _reduce_dataset(ds: HfDataset):
+            features = None
+            if 'history' in ds.features:
+                features = ds.features.copy()
+                features['_history'] = Sequence(feature=Sequence(feature=Value(dtype='string')))
+                features['_system'] = Value(dtype='string')
+            ds = ds.map(_reduce_column, load_from_cache_file=False, features=features)
+            if 'history' in ds.features:
+                ds = ds.remove_columns(['history']).rename_column('_history', 'history')
+            if 'system' in ds.features:
+                ds = ds.remove_columns(['system']).rename_column('_system', 'system')
+            return ds
 
         train_d: HfDataset
         if isinstance(dataset, (list, tuple)):
@@ -2255,9 +2277,9 @@ def get_dataset(
             train_d, val_d = dataset, None
 
         if train_d:
-            train_d = train_d.map(_reduce_column)
+            train_d = _reduce_dataset(train_d)
         if val_d:
-            val_d = val_d.map(_reduce_column)
+            val_d = _reduce_dataset(val_d)
 
         assert train_d is not None or val_d is not None
         if train_d is not None:

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -101,7 +101,7 @@ class AlpacaPreprocessor(MediaMixin, RowPreprocessMixin):
         inp: Optional[str] = d.get('input', None)
         h, output = d.pop('history', None), d['output']
         sys = d.pop('system', None)
-        tool = d.pop('tools', [])
+        tool = d.pop('tools')
         if output is None:
             return self.empty_row
         if inp is None or len(inp) == 0:
@@ -189,7 +189,7 @@ class ConversationsPreprocessor(MediaMixin, RowPreprocessMixin):
             response = conversations[-1][self.value_key]
             system = sys
             history = h
-            tools = d.get('tools')
+            tools = d.get('tools', [])
             row = {'system': system, 'history': history, 'history_roles': hr}
             row.update({
                 'query': query,

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -51,7 +51,7 @@ class MediaMixin:
             'response': '',
             'tools': None,
             'system': None,
-            'history': [],
+            'history': None,
         }
         if self.media_type and not isinstance(self.media_key, str):
             empty_row[self.media_name] = None
@@ -189,7 +189,7 @@ class ConversationsPreprocessor(MediaMixin, RowPreprocessMixin):
             response = conversations[-1][self.value_key]
             system = sys
             history = h
-            tools = d.get('tools', [])
+            tools = d.get('tools')
             row = {'system': system, 'history': history, 'history_roles': hr}
             row.update({
                 'query': query,

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -101,7 +101,7 @@ class AlpacaPreprocessor(MediaMixin, RowPreprocessMixin):
         inp: Optional[str] = d.get('input', None)
         h, output = d.pop('history', None), d['output']
         sys = d.pop('system', None)
-        tool = d.pop('tools', None)
+        tool = d.pop('tools', [])
         if output is None:
             return self.empty_row
         if inp is None or len(inp) == 0:

--- a/swift/llm/utils/preprocess.py
+++ b/swift/llm/utils/preprocess.py
@@ -101,7 +101,7 @@ class AlpacaPreprocessor(MediaMixin, RowPreprocessMixin):
         inp: Optional[str] = d.get('input', None)
         h, output = d.pop('history', None), d['output']
         sys = d.pop('system', None)
-        tool = d.pop('tools')
+        tool = d.pop('tools', None)
         if output is None:
             return self.empty_row
         if inp is None or len(inp) == 0:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Dataset concatenation may raise following errors:

```text
_check_if_features_can_be_aligned
    raise ValueError(
ValueError: The features can't be aligned because the key history of features {'system': Value(dtype='null', id=None), 'history': Sequence(feature=Sequence(feature=Value(dtype='string', id=None), length=-1, id=None), length=-1, id=None), 'query': Value(dtype='string', id=None), 'response': Value(dtype='string', id=None)} has unexpected type - Sequence(feature=Sequence(feature=Value(dtype='string', id=None), length=-1, id=None), length=-1, id=None) (expected either Sequence(feature=Value(dtype='null', id=None), length=-1, id=None) or Value("null").
```

This is because some dataset has empty values and None values, and another one has normal history values, so the arrow_dataset will treat them as difference types.

How to solve:

reduce column after the dataset instantiated, and before the concatenation.

## Experiment results

Paste your experiment result here(if needed).
