### PR TITLE
[TorchAcc] Add acc_steps arguments to speed up torchacc training

### DIFF
--- a/docs/source/LLM/命令行参数.md
+++ b/docs/source/LLM/命令行参数.md
@@ -92,6 +92,7 @@
 - `--save_only_model`: 是否只保存模型参数, 而不存储断点续训所需的中间状态, 默认为`None`, 即如果`sft_type`为'lora'并且不使用deepspeed(`deepspeed`为`None`), 设置为False, 否则设置为True(e.g. 使用了全参数微调或者使用了deepspeed).
 - `--save_total_limit`: 保存的checkpoint的数量, 默认为`2`, 即保存best和last的checkpoint. 如果设置为-1, 则保存所有的checkpoint.
 - `--logging_steps`: 每训练多少步打印训练信息(e.g. loss, learning_rate等), 默认为`5`.
+- `--acc_steps`: 每训练多少步计算一次accuracy信息，默认为`1`.
 - `--dataloader_num_workers`: 默认值为`None`, 如果是windows机器, 则设置为`0`, 否则设置为`1`.
 - `--push_to_hub`: 是否将训练的checkpoint同步推送到ModelScope Hub中, 默认为`False`.
 - `--hub_model_id`: 推送到的ModelScope Hub的model_id, 默认为`None`, 即设置为`f'{model_type}-{sft_type}'`. 你可以将其设置为model_id, 也可以设置为repo_name. 我们会根据hub_token推断出user_name. 推送的远程仓库如果不存在, 则会创建一个新的仓库, 如果存在, 则复用之前的仓库. 该参数只有在`push_to_hub`设置为True时才生效.

--- a/docs/source_en/LLM/Command-line-parameters.md
+++ b/docs/source_en/LLM/Command-line-parameters.md
@@ -93,6 +93,7 @@
 - `--save_only_model`: Whether to save only model parameters, without saving intermediate states needed for checkpoint resuming, default is `None`, i.e. if `sft_type` is 'lora' and not using deepspeed (`deepspeed` is `None`), set to False, otherwise set to True (e.g. using full fine-tuning or deepspeed).
 - `--save_total_limit`: Number of checkpoints to save, default is `2`, i.e. save best and last checkpoint. If set to -1, save all checkpoints.
 - `--logging_steps`: Print training information (e.g. loss, learning_rate, etc.) every this many steps, default is `5`.
+- `--acc_steps`: How often to calculate the accuracy information during training, by default it is calculated every `1` iteration.
 - `--dataloader_num_workers`: Default value is `None`. If running on a Windows machine, set it to `0`; otherwise, set it to `1`.
 - `--push_to_hub`: Whether to sync push trained checkpoint to ModelScope Hub, default is `False`.
 - `--hub_model_id`: Model_id to push to on ModelScope Hub, default is `None`, i.e. set to `f'{model_type}-{sft_type}'`. You can set this to model_id or repo_name. We will infer user_name based on hub_token. If the remote repository to push to does not exist, a new repository will be created, otherwise the previous repository will be reused. This parameter only takes effect when `push_to_hub` is set to True.

--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
@@ -31,6 +31,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
@@ -30,6 +30,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 2 \

--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/swift_lora_sft.sh
@@ -22,6 +22,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
@@ -32,6 +32,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
@@ -31,6 +31,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 2 \

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/swift_lora_sft.sh
@@ -22,6 +22,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
@@ -32,6 +32,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
@@ -32,6 +32,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 2 \

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/swift_lora_sft.sh
@@ -22,6 +22,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
@@ -33,6 +33,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
@@ -32,6 +32,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 2 \

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/swift_lora_sft.sh
@@ -23,6 +23,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
@@ -31,6 +31,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
@@ -33,6 +33,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 2 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/swift_lora_sft.sh
@@ -22,5 +22,6 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
@@ -30,6 +30,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 4 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/swift_lora_sft.sh
@@ -22,5 +22,6 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
@@ -31,6 +31,7 @@ swift sft \
     --eval_steps 200 \
     --save_steps 200 \
     --logging_steps 100 \
+    --acc_steps 100 \
     --metric_warmup_step 0.1 \
     --report_to 'none'
     --fsdp_num 32

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
@@ -28,6 +28,7 @@ swift sft \
     --eval_steps 200 \
     --save_steps 200 \
     --logging_steps 100 \
+    --acc_steps 100 \
     --metric_warmup_step 0.1 \
     --report_to 'none' \
     --fsdp_num 4 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/swift_lora_sft.sh
@@ -4,8 +4,8 @@
 
 # MASTER_ADDR=127.0.0.1 \
 
-NPROC_PER_NODE=2 \
-CUDA_VISIBLE_DEVICES=0,1,2,3 \
+NPROC_PER_NODE=1 \
+CUDA_VISIBLE_DEVICES=7 \
 swift sft \
   --model_id_or_path qwen/Qwen-72B-Chat \
   --dataset codefuse-python-en \
@@ -22,5 +22,6 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \

--- a/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
@@ -30,6 +30,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --fsdp_num 4 \

--- a/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/swift_lora_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/swift_lora_sft.sh
@@ -22,6 +22,7 @@ swift sft \
   --eval_steps 2000000 \
   --save_steps 2000000 \
   --logging_steps 100 \
+  --acc_steps 100 \
   --preprocess_num_proc 1 \
   --metric_warmup_step 0.1 \
   --report_to 'none'

--- a/swift/llm/utils/argument.py
+++ b/swift/llm/utils/argument.py
@@ -580,6 +580,7 @@ class SftArguments(ArgumentsBase):
     save_only_model: Optional[bool] = None
     save_total_limit: int = 2  # save last and best. -1: all checkpoints
     logging_steps: int = 5
+    acc_steps: int = 1
     dataloader_num_workers: Optional[int] = None
     dataloader_pin_memory: bool = True
     dataloader_drop_last: bool = False

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -214,24 +214,26 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
         acc_strategy = getattr(self.args, 'acc_strategy', 'token')
         acc: Optional[Tensor] = None
 
-        if preds.shape != labels.shape:
-            pass
-        elif acc_strategy == 'sentence':
-            acc_list = []
-            for i, m in enumerate(masks):
-                acc_list.append(torch.all(preds[i, m] == labels[i, m]).to(torch.int64).item())
-            acc = torch.tensor(acc_list, device=preds.device).float().mean()
-        else:
-            if use_torchacc():
-                ta_trim_graph()
-                preds = preds.to('cpu')
-                masks = masks.to('cpu')
-                labels = labels.to('cpu')
-            acc = (torch.masked_select(preds, masks) == torch.masked_select(labels, masks)).float().mean()
-        if model.training and acc is not None:
-            if 'acc' not in self._custom_metrics:
-                self._custom_metrics['acc'] = self._acc
-            self._custom_metrics['acc'] = self._custom_metrics['acc'] + acc / self.args.gradient_accumulation_steps
+        if self.state.global_step % self.sft_args.acc_steps == 0:
+            print('calc acc....')
+            if preds.shape != labels.shape:
+                pass
+            elif acc_strategy == 'sentence':
+                acc_list = []
+                for i, m in enumerate(masks):
+                    acc_list.append(torch.all(preds[i, m] == labels[i, m]).to(torch.int64).item())
+                acc = torch.tensor(acc_list, device=preds.device).float().mean()
+            else:
+                if use_torchacc():
+                    ta_trim_graph()
+                    preds = preds.to('cpu')
+                    masks = masks.to('cpu')
+                    labels = labels.to('cpu')
+                acc = (torch.masked_select(preds, masks) == torch.masked_select(labels, masks)).float().mean()
+            if model.training and acc is not None:
+                if 'acc' not in self._custom_metrics:
+                    self._custom_metrics['acc'] = self._acc
+                self._custom_metrics['acc'] = self._custom_metrics['acc'] + acc / self.args.gradient_accumulation_steps
         return (loss, outputs) if return_outputs else loss
 
     def get_train_dataloader(self):

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -215,7 +215,6 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
         acc: Optional[Tensor] = None
 
         if self.state.global_step % self.sft_args.acc_steps == 0:
-            print('calc acc....')
             if preds.shape != labels.shape:
                 pass
             elif acc_strategy == 'sentence':


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

# Test result

llama3-8b

method | train_sample/s | train_sample/s after warmup
-- | -- | --
acc2.3 + 2ddp+acc_steps100 | 12.608 | 14.554
acc2.3 + 2ddp+acc_steps1 | 10.096 | 11.304

</article>
