### PR TITLE
fix bug in _prepare_inputs

### DIFF
--- a/swift/llm/utils/utils.py
+++ b/swift/llm/utils/utils.py
@@ -582,7 +582,7 @@ def _prepare_inputs(model: PreTrainedModel,
     truncation_strategy = kwargs.pop('truncation_strategy', 'delete')
     if len(inputs) == 0 and truncation_strategy == 'delete':
         # input_ids exceeds `max_length`. Please increase the value of `max_length`.
-        return {}, tokenizer_kwargs, 0
+        return {}, tokenizer_kwargs, 0, example
 
     inputs.pop('labels', None)
     tokenizer = template.tokenizer


### PR DESCRIPTION
swift/swift/llm/utils/utils.py里面第585行，应该返回4个变量，不然第763行会报错。
return {}, tokenizer_kwargs, 0
--->
return {}, tokenizer_kwargs, 0, example
