### PR TITLE
[TorchAcc] Update patch for transformers>=4.41.0

### DIFF
--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -5,8 +5,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import json
 import torch
+import transformers
 from datasets import Dataset as HfDataset
 from modelscope import BitsAndBytesConfig, GenerationConfig
+from packaging import version
 from transformers import IntervalStrategy
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import is_torch_npu_available
@@ -427,8 +429,9 @@ def get_sft_main(args, llm):
     if use_torchacc():
         logger.warning('TorchAcc is currently only available internally within Alibaba Cloud.')
         import torchacc as ta
-        # This patch should be called before `llm_sft`.
-        ta.accelerate_hf_trainer()
+        if version.parse(transformers.__version__) < version.parse('4.41.0'):
+            # This patch should be called before `llm_sft`.
+            ta.accelerate_hf_trainer()
     return get_main(args, llm)
 
 

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -379,13 +379,7 @@ def patch_acc_model(model, args):
 
 def patch_llama_model(model):
 
-    def update_causal_mask(
-        self,
-        attention_mask: torch.Tensor,
-        input_tensor: torch.Tensor,
-        cache_position: torch.Tensor,
-        past_seen_tokens: int,
-    ):
+    def update_causal_mask(self, *args, **kwargs):
         # attention_mask is not supported in TorchAcc.
         return None
 
@@ -443,7 +437,7 @@ def patch_llama_model(model):
     for layer in model.model.layers:
         layer.self_attn.forward = types.MethodType(llama_attn_forward, layer.self_attn)
 
-    if version.parse(transformers.__version__) >= version.parse('4.40'):
+    if version.parse(transformers.__version__) >= version.parse('4.38'):
         model.model._update_causal_mask = types.MethodType(update_causal_mask, model.model)
 
     return model


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

1. Update TorchAcc patch for transformers when it's version >=4.41.0;
2. Update `update_causal_mask` in llama patch.

## Experiment results

Paste your experiment result here(if needed).
